### PR TITLE
Count PISTON_HEAD and MOVING_PISTON + Config option to ignore custom limits perms

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/JoinListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/JoinListener.java
@@ -39,6 +39,9 @@ public class JoinListener implements Listener {
     }
 
     private void checkPerms(Player player, String permissionPrefix, String islandId, String gameMode) {
+        if (!addon.getConfig().getBoolean("usepermissions", true)) {
+            return;
+        }
         IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(islandId);
         if (ibc != null) {
             // Clear permission limits

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,10 @@ gamemodes:
 # example: bskyblock.island.limit.hopper.10
 # permission activates when player logs in.
 #
+#¿Do you want to use perms to add custom limits to islands?
+#Set it to false if you are a developer and want to handle the custom limit via code
+usepermissions: true
+
 # Cooldown for player recount command in seconds
 cooldown: 120
 


### PR DESCRIPTION
When players break pistons which are extended or moving, they are not removed from the limit.

In order to resolve this, I had to change fixMaterial(Material) to fixMaterial(Block). Then get the BlockData "TechnicalPiston" in order to know if the PISTON_HEAD/MOVING_PISTON  is from NORMAL or STICKY.

Then I realised fixMaterial was being used for others things (https://github.com/BentoBoxWorld/Limits/blob/develop/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java#L336) so I couldn't just change the argument from Material to Block, so I set it to Object. Then I cast it to know if it is Block or Material.

I don't really understand why "changeTo" exists. I guess because of this line: https://github.com/BentoBoxWorld/Limits/blob/develop/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java#L173 but I don't know how is it possible to break seeds.
