### PR TITLE
Fixes wrong placeholder value #159

### DIFF
--- a/src/main/java/world/bentobox/limits/Limits.java
+++ b/src/main/java/world/bentobox/limits/Limits.java
@@ -191,11 +191,11 @@ public class Limits extends Addon {
         if (is == null) {
             return LIMIT_NOT_SET;
         }
-        @Nullable IslandBlockCount ibc = getBlockLimitListener().getIsland(is.getUniqueId());
-        if (ibc == null) {
-            return LIMIT_NOT_SET;
-        }
-        int limit = ibc.getBlockLimit(m);
+
+        int limit = this.getBlockLimitListener().
+            getMaterialLimits(is.getWorld(), is.getUniqueId()).
+            getOrDefault(m, -1);
+
         return limit == -1 ? LIMIT_NOT_SET : String.valueOf(limit);
     }
 

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -431,7 +431,12 @@ public class BlockLimitsListener implements Listener {
         }
         // Island
         if (islandCountMap.containsKey(id)) {
-            result.putAll(islandCountMap.get(id).getBlockLimits());
+            IslandBlockCount islandBlockCount = islandCountMap.get(id);
+            result.putAll(islandBlockCount.getBlockLimits());
+
+            // Add offsets to the every limit.
+            islandBlockCount.getBlockLimitsOffset().forEach((material, offset) ->
+                result.put(material, result.getOrDefault(material, 0) + offset));
         }
         return result;
     }


### PR DESCRIPTION
Placeholder value did not check default and world limits. It used just island limits that are assigned via permissions.

This commit should fix it.