### PR TITLE
Add a config option to disable logging player limits to console (on join)

### DIFF
--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -27,6 +27,7 @@ public class Settings {
     private final Map<EntityType, Integer> limits = new EnumMap<>(EntityType.class);
     private final Map<EntityType, List<EntityGroup>> groupLimits = new EnumMap<>(EntityType.class);
     private final List<String> gameModes;
+    private final boolean logLimitsOnJoin;
     private final boolean asyncGolums;
     private static final List<EntityType> DISALLOWED = Arrays.asList(
             EntityType.TNT,
@@ -79,6 +80,8 @@ public class Settings {
                 }
             }
         }
+        // Log limits on join
+        logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", true);
         // Async Golums
         asyncGolums = addon.getConfig().getBoolean("async-golums", true);
 
@@ -156,6 +159,13 @@ public class Settings {
      */
     public List<String> getGameModes() {
         return gameModes;
+    }
+
+    /**
+     * @return the logLimitsOnJoin
+     */
+    public boolean isLogLimitsOnJoin() {
+        return logLimitsOnJoin;
     }
 
     /**

--- a/src/main/java/world/bentobox/limits/listeners/JoinListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/JoinListener.java
@@ -86,7 +86,8 @@ public class JoinListener implements Listener {
             }
             // Get the value
             int value = Integer.parseInt(split[4]);
-            addon.log("Setting login limit via perm for " + player.getName() + "...");
+            if(addon.getSettings().isLogLimitsOnJoin())
+                addon.log("Setting login limit via perm for " + player.getName() + "...");
 
             // Fire perm check event
             LimitsPermCheckEvent l = new LimitsPermCheckEvent(player, islandId, ibc, entgroup, et, m, value);
@@ -143,26 +144,32 @@ public class JoinListener implements Listener {
             // Entity group limit
             int v = Math.max(ibc.getEntityGroupLimit(entgroup.getName()), value);
             ibc.setEntityGroupLimit(entgroup.getName(), v);
-            addon.log("Setting group limit " + entgroup.getName() + " " + v);
+            if(addon.getSettings().isLogLimitsOnJoin())
+                addon.log("Setting group limit " + entgroup.getName() + " " + v);
         } else if (et != null && m == null) {
             // Entity limit
             int v = Math.max(ibc.getEntityLimit(et), value);
             ibc.setEntityLimit(et, v);
-            addon.log("Setting entity limit " + et + " " + v);
+            if(addon.getSettings().isLogLimitsOnJoin())
+                addon.log("Setting entity limit " + et + " " + v);
         } else if (m != null && et == null) {
             // Block limit
             int v = Math.max(ibc.getBlockLimit(m), value);
-            addon.log("Setting block limit " + m + " " + v);
+            if(addon.getSettings().isLogLimitsOnJoin())
+                addon.log("Setting block limit " + m + " " + v);
             ibc.setBlockLimit(m, v);
         } else {
             if (m != null && m.isBlock()) {
                 int v = Math.max(ibc.getBlockLimit(m), value);
-                addon.log("Setting block limit " + m + " " + v);
+                if(addon.getSettings().isLogLimitsOnJoin())
+                    addon.log("Setting block limit " + m + " " + v);
                 // Material limit
-                ibc.setBlockLimit(m, v);
+                if(addon.getSettings().isLogLimitsOnJoin())
+                    ibc.setBlockLimit(m, v);
             } else if (et != null) {
                 int v = Math.max(ibc.getEntityLimit(et), value);
-                addon.log("Setting entity limit " + et + " " + v);
+                if(addon.getSettings().isLogLimitsOnJoin())
+                    addon.log("Setting entity limit " + et + " " + v);
                 // This is an entity setting
                 ibc.setEntityLimit(et, v);
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,9 @@ ignore-center-block: true
 # Cooldown for player recount command in seconds
 cooldown: 120
 
+# Log limits on join (to console)
+log-limits-on-join: true
+
 # Use async checks for snowmen and iron golums. Set to false if you see problems.
 async-golums: true
 


### PR DESCRIPTION
Reasoning: currently limits are printed for every player on Join which can be very spammy in console and log files.