### PR TITLE
feat(limits): add configurable auto-refresh and harden limit persistence

### DIFF
--- a/src/main/java/world/bentobox/limits/Limits.java
+++ b/src/main/java/world/bentobox/limits/Limits.java
@@ -44,6 +44,9 @@ public class Limits extends Addon {
 
     @Override
     public void onDisable() {
+        if (joinListener != null) {
+            joinListener.stopAutoRefreshTask();
+        }
         if (blockLimitListener != null) {
             blockLimitListener.save();
         }
@@ -74,6 +77,7 @@ public class Limits extends Addon {
         registerListener(blockLimitListener);
         joinListener = new JoinListener(this);
         registerListener(joinListener);
+        joinListener.startAutoRefreshTask();
         EntityLimitListener entityLimitListener = new EntityLimitListener(this);
         registerListener(entityLimitListener);
         // Register Paper-specific listener for shulker duplication limiting if running on Paper.

--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -29,6 +29,7 @@ public class Settings {
     private final List<String> gameModes;
     private final boolean logLimitsOnJoin;
     private final boolean asyncGolums;
+    private final int autoRefreshSeconds;
     private static final List<EntityType> DISALLOWED = Arrays.asList(
             EntityType.TNT,
             EntityType.EVOKER_FANGS,
@@ -84,6 +85,8 @@ public class Settings {
         logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", true);
         // Async Golums
         asyncGolums = addon.getConfig().getBoolean("async-golums", true);
+        // Auto refresh interval for permission limits/audit task in seconds. 0 disables it.
+        autoRefreshSeconds = Math.max(0, addon.getConfig().getInt("auto-refresh-seconds", 3600));
 
         addon.log("Entity limits:");
         limits.entrySet().stream().map(e -> "Limit " + e.getKey().toString() + " to " + e.getValue()).forEach(addon::log);
@@ -173,6 +176,13 @@ public class Settings {
      */
     public boolean isAsyncGolums() {
         return asyncGolums;
+    }
+
+    /**
+     * @return auto-refresh interval in seconds. 0 means disabled.
+     */
+    public int getAutoRefreshSeconds() {
+        return autoRefreshSeconds;
     }
 
     /**

--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -95,10 +95,10 @@ public class RecountCalculator {
         }
     }
 
-    private void checkBlock(BlockData b) {
+    private void checkBlock(World scanWorld, BlockData b) {
         NamespacedKey md = bll.fixMaterial(b);
         // md is limited
-        if (bll.getMaterialLimits(world, island.getUniqueId()).containsKey(md)) {
+        if (bll.getMaterialLimits(scanWorld, island.getUniqueId()).containsKey(md)) {
             results.mdCount.add(md);
         }
     }
@@ -211,7 +211,7 @@ public class RecountCalculator {
                     if (Tag.SLABS.isTagged(blockData.getMaterial())) {
                         Slab slab = (Slab)blockData;
                         if (slab.getType().equals(Slab.Type.DOUBLE)) {
-                            checkBlock(blockData);
+                            checkBlock(chunk.getWorld(), blockData);
                         }
                     }
                     // Hook for Wild Stackers (Blocks Only) - this has to use the real chunk
@@ -221,7 +221,7 @@ public class RecountCalculator {
                     }
                      */
                     // Add the value of the block's material
-                    checkBlock(blockData);
+                    checkBlock(chunk.getWorld(), blockData);
                 }
             }
         }

--- a/src/main/java/world/bentobox/limits/commands/admin/OffsetCommand.java
+++ b/src/main/java/world/bentobox/limits/commands/admin/OffsetCommand.java
@@ -166,6 +166,7 @@ public class OffsetCommand extends CompositeCommand
             {
                 islandData.setBlockLimitsOffset(material.getKey(), offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.set.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -175,6 +176,7 @@ public class OffsetCommand extends CompositeCommand
             {
                 islandData.setEntityLimitsOffset(entityType, offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.set.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -281,6 +283,7 @@ public class OffsetCommand extends CompositeCommand
 
                 islandData.setBlockLimitsOffset(material.getKey(), offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.add.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -292,6 +295,7 @@ public class OffsetCommand extends CompositeCommand
 
                 islandData.setEntityLimitsOffset(entityType, offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.add.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -398,6 +402,7 @@ public class OffsetCommand extends CompositeCommand
 
                 islandData.setBlockLimitsOffset(material.getKey(), offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.remove.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -409,6 +414,7 @@ public class OffsetCommand extends CompositeCommand
 
                 islandData.setEntityLimitsOffset(entityType, offset);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.remove.success",
                     TextVariables.NUMBER, String.valueOf(offset),
@@ -504,6 +510,7 @@ public class OffsetCommand extends CompositeCommand
             {
                 islandData.setBlockLimitsOffset(material.getKey(), 0);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.reset.success",
                     TextVariables.NAME, material.name());
@@ -512,6 +519,7 @@ public class OffsetCommand extends CompositeCommand
             {
                 islandData.setEntityLimitsOffset(entityType, 0);
                 islandData.setChanged();
+                this.addon.getBlockLimitListener().setIsland(island.getUniqueId(), islandData);
 
                 user.sendMessage("admin.limits.offset.reset.success",
                     TextVariables.NAME, entityType.name());

--- a/src/main/java/world/bentobox/limits/listeners/JoinListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/JoinListener.java
@@ -1,14 +1,20 @@
 package world.bentobox.limits.listeners;
 
 import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,16 +22,20 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.scheduler.BukkitTask;
 import org.eclipse.jdt.annotation.NonNull;
 
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.Reason;
 import world.bentobox.bentobox.api.events.team.TeamSetownerEvent;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.limits.EntityGroup;
 import world.bentobox.limits.Limits;
 import world.bentobox.limits.events.LimitsJoinPermCheckEvent;
 import world.bentobox.limits.events.LimitsPermCheckEvent;
+import world.bentobox.limits.listeners.BlockLimitsListener;
 import world.bentobox.limits.objects.IslandBlockCount;
 
 /**
@@ -39,6 +49,7 @@ import world.bentobox.limits.objects.IslandBlockCount;
 public class JoinListener implements Listener {
 
     private final Limits addon;
+    private BukkitTask autoRefreshTask;
 
     /**
      * Constructs the listener.
@@ -46,6 +57,156 @@ public class JoinListener implements Listener {
      */
     public JoinListener(Limits addon) {
         this.addon = addon;
+    }
+
+    /**
+     * Starts periodic permission refresh and limit-breach audit.
+     */
+    public void startAutoRefreshTask() {
+        if (autoRefreshTask != null) {
+            return;
+        }
+        int refreshSeconds = addon.getSettings().getAutoRefreshSeconds();
+        if (refreshSeconds <= 0) {
+            addon.log("Limits auto-refresh is disabled (auto-refresh-seconds <= 0).");
+            return;
+        }
+        long intervalTicks = Math.max(20L, refreshSeconds * 20L);
+        autoRefreshTask = Bukkit.getScheduler().runTaskTimer(addon.getPlugin(),
+                this::refreshOnlineOwnerLimitsAndAudit,
+                intervalTicks,
+                intervalTicks);
+        addon.log("Limits auto-refresh enabled: every " + refreshSeconds + " seconds.");
+    }
+
+    /**
+     * Stops periodic refresh task.
+     */
+    public void stopAutoRefreshTask() {
+        if (autoRefreshTask != null) {
+            autoRefreshTask.cancel();
+            autoRefreshTask = null;
+        }
+    }
+
+    private void refreshOnlineOwnerLimitsAndAudit() {
+        for (GameModeAddon gameMode : addon.getGameModes()) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                refreshPlayerIslands(gameMode, player);
+            }
+        }
+    }
+
+    private void refreshPlayerIslands(GameModeAddon gameMode, Player player) {
+        addon.getIslands().getIslands(gameMode.getOverWorld(), player.getUniqueId()).stream()
+                .filter(island -> player.getUniqueId().equals(island.getOwner()))
+                .forEach(island -> {
+                    String islandId = island.getUniqueId();
+                    IslandBlockCount islandBlockCount = addon.getBlockLimitListener().getIsland(islandId);
+                    if (!joinEventCheck(player, islandId, islandBlockCount)) {
+                        checkPerms(player, gameMode.getPermissionPrefix() + "island.limit.", islandId,
+                                gameMode.getDescription().getName());
+                    }
+                    auditIslandLimitBreaches(island, player.getName());
+                });
+    }
+
+    private void auditIslandLimitBreaches(Island island, String ownerName) {
+        IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island.getUniqueId());
+        if (ibc == null) {
+            return;
+        }
+        auditBlockLimitBreaches(island, ownerName, ibc);
+        Map<EntityType, Integer> entityCounts = countEntitiesInIslandSpace(island);
+        auditEntityLimitBreaches(island, ownerName, ibc, entityCounts);
+        auditEntityGroupLimitBreaches(island, ownerName, ibc, entityCounts);
+    }
+
+    private void auditBlockLimitBreaches(Island island, String ownerName, IslandBlockCount ibc) {
+        Map<NamespacedKey, Integer> materialLimits = addon.getBlockLimitListener()
+                .getMaterialLimits(island.getWorld(), island.getUniqueId());
+        materialLimits.forEach((material, limit) -> {
+            if (limit < 0) {
+                return;
+            }
+            int count = ibc.getBlockCount(material);
+            if (count > limit) {
+                warnLimitBreach(ownerName, island, "block", material.toString(), count, limit);
+            }
+        });
+    }
+
+    private void auditEntityLimitBreaches(Island island, String ownerName, IslandBlockCount ibc,
+            Map<EntityType, Integer> entityCounts) {
+        Set<EntityType> limitedTypes = new HashSet<>(addon.getSettings().getLimits().keySet());
+        limitedTypes.addAll(ibc.getEntityLimits().keySet());
+        for (EntityType type : limitedTypes) {
+            int baseLimit = ibc.getEntityLimit(type);
+            if (baseLimit < 0) {
+                baseLimit = addon.getSettings().getLimits().getOrDefault(type, -1);
+            }
+            if (baseLimit < 0) {
+                continue;
+            }
+            int limit = baseLimit + ibc.getEntityLimitOffset(type);
+            int count = entityCounts.getOrDefault(type, 0);
+            if (count > limit) {
+                warnLimitBreach(ownerName, island, "entity", type.name(), count, limit);
+            }
+        }
+    }
+
+    private void auditEntityGroupLimitBreaches(Island island, String ownerName, IslandBlockCount ibc,
+            Map<EntityType, Integer> entityCounts) {
+        for (EntityGroup group : addon.getSettings().getGroupLimitDefinitions()) {
+            int baseLimit = ibc.getEntityGroupLimit(group.getName());
+            if (baseLimit < 0) {
+                baseLimit = group.getLimit();
+            }
+            if (baseLimit < 0) {
+                continue;
+            }
+            int limit = baseLimit + ibc.getEntityGroupLimitOffset(group.getName());
+            int count = group.getTypes().stream().mapToInt(type -> entityCounts.getOrDefault(type, 0)).sum();
+            if (count > limit) {
+                warnLimitBreach(ownerName, island, "entity-group", group.getName(), count, limit);
+            }
+        }
+    }
+
+    private Map<EntityType, Integer> countEntitiesInIslandSpace(Island island) {
+        Map<EntityType, Integer> counts = new EnumMap<>(EntityType.class);
+        World world = island.getWorld();
+        collectEntityCounts(island, world, counts);
+        IslandWorldManager iwm = addon.getPlugin().getIWM();
+        if (iwm.isNetherIslands(world) && iwm.getNetherWorld(world) != null) {
+            collectEntityCounts(island, iwm.getNetherWorld(world), counts);
+        }
+        if (iwm.isEndIslands(world) && iwm.getEndWorld(world) != null) {
+            collectEntityCounts(island, iwm.getEndWorld(world), counts);
+        }
+        return counts;
+    }
+
+    private void collectEntityCounts(Island island, World world, Map<EntityType, Integer> counts) {
+        for (Entity entity : world.getEntities()) {
+            if (island.inIslandSpace(entity.getLocation())) {
+                counts.merge(entity.getType(), 1, Integer::sum);
+            }
+        }
+    }
+
+    private void warnLimitBreach(String ownerName, Island island, String type, String target, int count, int limit) {
+        Bukkit.getLogger().warning("[Limits] Auto-refresh detected " + type + " limit breach: island="
+                + island.getUniqueId()
+                + ", owner="
+                + ownerName
+                + ", target="
+                + target
+                + ", count="
+                + count
+                + ", limit="
+                + limit);
     }
 
     /**
@@ -312,12 +473,15 @@ public class JoinListener implements Listener {
     private void removeOwnerPerms(Island island) {
         World world = island.getWorld();
         if (addon.inGameModeWorld(world)) {
-            IslandBlockCount islandBlockCount = addon.getBlockLimitListener().getIsland(island.getUniqueId());
+            BlockLimitsListener blockLimitsListener = addon.getBlockLimitListener();
+            IslandBlockCount islandBlockCount = blockLimitsListener.getIsland(island.getUniqueId());
             if (islandBlockCount != null) {
                 // Just clear the maps. This preserves any actual block counts.
                 islandBlockCount.getBlockLimits().clear();
                 islandBlockCount.getEntityLimits().clear();
                 islandBlockCount.getEntityGroupLimits().clear();
+                islandBlockCount.setChanged();
+                blockLimitsListener.setIsland(island.getUniqueId(), islandBlockCount);
             }
         }
     }

--- a/src/main/java/world/bentobox/limits/objects/IslandBlockCount.java
+++ b/src/main/java/world/bentobox/limits/objects/IslandBlockCount.java
@@ -3,7 +3,6 @@ package world.bentobox.limits.objects;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -77,7 +76,7 @@ public class IslandBlockCount implements DataObject {
      * Clear all island-specific entity group limits
      */
     public void clearEntityGroupLimits() {
-        entityGroupLimits.clear();
+        getEntityGroupLimits().clear();
         setChanged();
     }
 
@@ -85,7 +84,7 @@ public class IslandBlockCount implements DataObject {
      * Clear all island-specific entity type limits
      */
     public void clearEntityLimits() {
-        entityLimits.clear();
+        getEntityLimits().clear();
         setChanged();
     }
 
@@ -173,7 +172,10 @@ public class IslandBlockCount implements DataObject {
      * @return the entityGroupLimits
      */
     public Map<String, Integer> getEntityGroupLimits() {
-        return Objects.requireNonNullElse(entityGroupLimits, new HashMap<>());
+        if (entityGroupLimits == null) {
+            entityGroupLimits = new HashMap<>();
+        }
+        return entityGroupLimits;
     }
 
     /**
@@ -210,7 +212,10 @@ public class IslandBlockCount implements DataObject {
      * @return the entityLimits
      */
     public Map<EntityType, Integer> getEntityLimits() {
-        return Objects.requireNonNullElse(entityLimits, new EnumMap<>(EntityType.class));
+        if (entityLimits == null) {
+            entityLimits = new EnumMap<>(EntityType.class);
+        }
+        return entityLimits;
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,11 @@ cooldown: 120
 # Log limits on join (to console)
 log-limits-on-join: true
 
+# Auto refresh interval (seconds) for rechecking owner permission limits and auditing
+# islands that are currently over their configured limits.
+# Set to 0 to disable scheduled auto refresh.
+auto-refresh-seconds: 3600
+
 # Use async checks for snowmen and iron golums. Set to false if you see problems.
 async-golums: true
 

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -103,6 +103,18 @@ public class SettingsTest {
     }
 
     @Test
+    public void testAutoRefreshDefaultsOneHour() {
+        assertEquals(3600, settings.getAutoRefreshSeconds());
+    }
+
+    @Test
+    public void testAutoRefreshCanBeOverridden() {
+        config.set("auto-refresh-seconds", 120);
+        Settings s = new Settings(addon);
+        assertEquals(120, s.getAutoRefreshSeconds());
+    }
+
+    @Test
     public void testGetGeneralEmpty() {
         // Default config.yml does not have ANIMALS or MOBS entries in entitylimits
         Map<Settings.GeneralGroup, Integer> general = settings.getGeneral();


### PR DESCRIPTION
Introduce a configurable auto-refresh loop for permission-based limits and add runtime auditing for islands above their effective limits.

Changes:

- add auto-refresh-seconds to config (default 3600, 0 disables scheduler)

- add Settings#getAutoRefreshSeconds() and parse value safely

- start/stop JoinListener auto-refresh task in addon lifecycle

- refresh online owners' island permission limits on schedule

- audit block/entity/entity-group limit breaches and emit console warnings for admins

- fix recount world resolution to evaluate material limits against the scanned world (normal/nether/end)

- fix IslandBlockCount null-handling for entity maps so deserialized null maps are reattached

- persist owner limit clears and admin offset changes immediately via setIsland()

- add Settings tests for auto-refresh default and override behavior

Validation:

- full suite passed with JDK 21: mvn test (222 tests, 0 failures, 0 errors)