### PR TITLE
Update Modrinth game-versions to current MC range

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -87,6 +87,9 @@ jobs:
             1.21.9
             1.21.10
             1.21.11
+            26.1
+            26.1.1
+            26.1.2
 
           # Path to the built JAR — Maven produces Limits-<version>.jar in target/
           # Note: glob patterns are not supported; use the release tag directly.


### PR DESCRIPTION
Updates the `game-versions` list in the Modrinth publish workflow to the standard current range used by the other BentoBox addons:

```
1.21.5  1.21.6  1.21.7  1.21.8  1.21.9  1.21.10  1.21.11  26.1  26.1.1  26.1.2
```

The list was stale and did not advertise the newer Minecraft versions on Modrinth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)