### PR TITLE
Fix block count leaks and parallelize recount chunk loading

### DIFF
--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -65,7 +66,7 @@ public class RecountCalculator {
         this.addon = addon;
         this.bll = addon.getBlockLimitListener();
         this.island = island;
-        this.ibc = bll.getIsland(Objects.requireNonNull(island).getUniqueId());
+        this.ibc = bll.getIsland(Objects.requireNonNull(island));
         this.r = r;
         results = new Results();
         chunksToCheck = getChunksToScan(island);
@@ -119,26 +120,23 @@ public class RecountCalculator {
 
     private CompletableFuture<List<Chunk>> getWorldChunk(Environment env, Queue<Pair<Integer, Integer>> pairList) {
         if (worlds.containsKey(env)) {
-            CompletableFuture<List<Chunk>> r2 = new CompletableFuture<>();
-            List<Chunk> chunkList = new ArrayList<>();
             World world = worlds.get(env);
-            loadChunks(r2, world, pairList, chunkList);
-            return r2;
+            boolean isNether = world.getEnvironment().equals(Environment.NETHER);
+            List<CompletableFuture<Chunk>> futures = new ArrayList<>();
+            while (!pairList.isEmpty()) {
+                Pair<Integer, Integer> p = pairList.poll();
+                futures.add(Util.getChunkAtAsync(world, p.x, p.z, isNether));
+            }
+            if (futures.isEmpty()) {
+                return CompletableFuture.completedFuture(Collections.emptyList());
+            }
+            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(v -> futures.stream()
+                            .map(CompletableFuture::join)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
         }
         return CompletableFuture.completedFuture(Collections.emptyList());
-    }
-
-    private void loadChunks(CompletableFuture<List<Chunk>> r2, World world, Queue<Pair<Integer, Integer>> pairList,
-            List<Chunk> chunkList) {
-        if (pairList.isEmpty()) {
-            r2.complete(chunkList);
-            return;
-        }
-        Pair<Integer, Integer> p = pairList.poll();
-        Util.getChunkAtAsync(world, p.x, p.z, world.getEnvironment().equals(Environment.NETHER)).thenAccept(chunk -> {
-            if (chunk != null) chunkList.add(chunk);
-            loadChunks(r2, world, pairList, chunkList);
-        });
     }
 
     private void scanAsync(Environment env, Chunk chunk) {
@@ -197,15 +195,16 @@ public class RecountCalculator {
         }
         Queue<Pair<Integer, Integer>> endPairList = new ConcurrentLinkedQueue<>(pairList);
         Queue<Pair<Integer, Integer>> netherPairList = new ConcurrentLinkedQueue<>(pairList);
-        CompletableFuture<Boolean> result = new CompletableFuture<>();
-        getWorldChunk(Environment.THE_END, endPairList).thenAccept(endChunks ->
-        scanChunk(Environment.THE_END, endChunks).thenAccept(b ->
-        getWorldChunk(Environment.NETHER, netherPairList).thenAccept(netherChunks ->
-        scanChunk(Environment.NETHER, netherChunks).thenAccept(b2 ->
-        getWorldChunk(Environment.NORMAL, pairList).thenAccept(normalChunks ->
-        scanChunk(Environment.NORMAL, normalChunks).thenAccept(b3 ->
-        result.complete(!chunksToCheck.isEmpty())))))));
-        return result;
+
+        CompletableFuture<List<Chunk>> endFuture = getWorldChunk(Environment.THE_END, endPairList);
+        CompletableFuture<List<Chunk>> netherFuture = getWorldChunk(Environment.NETHER, netherPairList);
+        CompletableFuture<List<Chunk>> normalFuture = getWorldChunk(Environment.NORMAL, pairList);
+
+        return CompletableFuture.allOf(endFuture, netherFuture, normalFuture)
+                .thenCompose(v -> scanChunk(Environment.THE_END, endFuture.join())
+                        .thenCompose(b -> scanChunk(Environment.NETHER, netherFuture.join()))
+                        .thenCompose(b2 -> scanChunk(Environment.NORMAL, normalFuture.join()))
+                        .thenApply(b3 -> !chunksToCheck.isEmpty()));
     }
 
     private void scanEntities() {
@@ -225,10 +224,7 @@ public class RecountCalculator {
     }
 
     public void tidyUp() {
-        if (ibc == null) {
-            ibc = new IslandBlockCount(island.getUniqueId(),
-                    addon.getPlugin().getIWM().getAddon(world).map(a -> a.getDescription().getName()).orElse("default"));
-        }
+        ibc = bll.getIsland(island);
         // Reset and write per-env block counts
         ibc.clearAllBlockCounts();
         results.getEnvBlockCount().forEach((env, multiset) -> multiset.forEach(key -> ibc.add(env, key)));

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -290,7 +290,11 @@ public class BlockLimitsListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBlock(BlockSpreadEvent e) {
-        process(e.getBlock(), true);
+        process(e.getBlock(), false);
+        if (process(e.getBlock(), e.getNewState().getBlockData(), true) > -1) {
+            e.setCancelled(true);
+            process(e.getBlock(), true);
+        }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -306,6 +310,7 @@ public class BlockLimitsListener implements Listener {
     public void onBlock(BlockGrowEvent e) {
         if (process(e.getNewState().getBlock(), true) > -1) {
             e.setCancelled(true);
+            process(e.getNewState().getBlock(), false);
             e.getBlock().getWorld().getBlockAt(e.getBlock().getLocation()).setBlockData(e.getBlock().getBlockData());
         } else {
             process(e.getBlock(), false);

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -579,6 +579,9 @@ public class BlockLimitsListenerTest {
         Block block = mockBlock(Material.GRASS_BLOCK, blockLocation);
         Block source = mockBlock(Material.GRASS_BLOCK, new Location(world, 101, 65, 100));
         BlockState newState = mock(BlockState.class);
+        BlockData newBlockData = mock(BlockData.class);
+        when(newBlockData.getMaterial()).thenReturn(Material.GRASS_BLOCK);
+        when(newState.getBlockData()).thenReturn(newBlockData);
         BlockSpreadEvent event = new BlockSpreadEvent(block, source, newState);
 
         listener.onBlock(event);


### PR DESCRIPTION
**Bug 1: BlockSpreadEvent never decremented the old block count**
When BlockSpreadEvent fired (grass spreading to dirt, fire spreading, etc.), the handler only incremented the new block's count — it never decremented the old block that was replaced. Over time, this permanently inflated counts for any material that could be overwritten by spread events. The fix follows the same pattern as BlockFormEvent: decrement the old block, attempt to add the new (with limit check), and if the limit is hit, cancel the event and revert.

**Bug 2: BlockGrowEvent leaked a count when the event was cancelled**
In the BlockGrowEvent handler, the new state's count was incremented before the limit check. If the check determined the limit was hit and cancelled the event, the increment was never rolled back — each failed growth attempt permanently added +1 to the count. The fix adds a process(newBlock, false) call after cancellation to revert the premature increment.

**Bug 3: RecountCalculator loaded chunks sequentially, causing timeout on large islands**
loadChunks() loaded chunks one at a time via recursive async chaining — 100 chunks × 3 environments = 300 sequential loads per iteration. For larger islands this easily exceeded the 5-minute CALCULATION_TIMEOUT, at which point tidyUp() was never called and the recount produced no results at all. The fix loads all chunks within an environment in parallel (CompletableFuture.allOf), and also loads all three environments in parallel, while keeping the actual block scanning sequential.

**Bug 4: RecountCalculator could create an IslandBlockCount without permission limits**
The constructor used the nullable getIsland(String) overload. If the island wasn't in the in-memory map, tidyUp() created a brand-new empty IslandBlockCount — losing all permission-based limits, offsets, and any limits set via JoinListener. The fix switches both the constructor and tidyUp() to the @NonNull getIsland(Island) overload (computeIfAbsent), which ensures limits are preserved from the existing map entry.