### PR TITLE
Fix block count leaks and parallelize recount chunk loading (supersedes #263)

### DIFF
--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -65,7 +66,7 @@ public class RecountCalculator {
         this.addon = addon;
         this.bll = addon.getBlockLimitListener();
         this.island = island;
-        this.ibc = bll.getIsland(Objects.requireNonNull(island).getUniqueId());
+        this.ibc = bll.getIsland(Objects.requireNonNull(island));
         this.r = r;
         results = new Results();
         chunksToCheck = getChunksToScan(island);
@@ -119,26 +120,23 @@ public class RecountCalculator {
 
     private CompletableFuture<List<Chunk>> getWorldChunk(Environment env, Queue<Pair<Integer, Integer>> pairList) {
         if (worlds.containsKey(env)) {
-            CompletableFuture<List<Chunk>> r2 = new CompletableFuture<>();
-            List<Chunk> chunkList = new ArrayList<>();
             World world = worlds.get(env);
-            loadChunks(r2, world, pairList, chunkList);
-            return r2;
+            boolean isNether = world.getEnvironment().equals(Environment.NETHER);
+            List<CompletableFuture<Chunk>> futures = new ArrayList<>();
+            while (!pairList.isEmpty()) {
+                Pair<Integer, Integer> p = pairList.poll();
+                futures.add(Util.getChunkAtAsync(world, p.x, p.z, isNether));
+            }
+            if (futures.isEmpty()) {
+                return CompletableFuture.completedFuture(Collections.emptyList());
+            }
+            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(v -> futures.stream()
+                            .map(CompletableFuture::join)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
         }
         return CompletableFuture.completedFuture(Collections.emptyList());
-    }
-
-    private void loadChunks(CompletableFuture<List<Chunk>> r2, World world, Queue<Pair<Integer, Integer>> pairList,
-            List<Chunk> chunkList) {
-        if (pairList.isEmpty()) {
-            r2.complete(chunkList);
-            return;
-        }
-        Pair<Integer, Integer> p = pairList.poll();
-        Util.getChunkAtAsync(world, p.x, p.z, world.getEnvironment().equals(Environment.NETHER)).thenAccept(chunk -> {
-            if (chunk != null) chunkList.add(chunk);
-            loadChunks(r2, world, pairList, chunkList);
-        });
     }
 
     private void scanAsync(Environment env, Chunk chunk) {
@@ -197,15 +195,16 @@ public class RecountCalculator {
         }
         Queue<Pair<Integer, Integer>> endPairList = new ConcurrentLinkedQueue<>(pairList);
         Queue<Pair<Integer, Integer>> netherPairList = new ConcurrentLinkedQueue<>(pairList);
-        CompletableFuture<Boolean> result = new CompletableFuture<>();
-        getWorldChunk(Environment.THE_END, endPairList).thenAccept(endChunks ->
-        scanChunk(Environment.THE_END, endChunks).thenAccept(b ->
-        getWorldChunk(Environment.NETHER, netherPairList).thenAccept(netherChunks ->
-        scanChunk(Environment.NETHER, netherChunks).thenAccept(b2 ->
-        getWorldChunk(Environment.NORMAL, pairList).thenAccept(normalChunks ->
-        scanChunk(Environment.NORMAL, normalChunks).thenAccept(b3 ->
-        result.complete(!chunksToCheck.isEmpty())))))));
-        return result;
+
+        CompletableFuture<List<Chunk>> endFuture = getWorldChunk(Environment.THE_END, endPairList);
+        CompletableFuture<List<Chunk>> netherFuture = getWorldChunk(Environment.NETHER, netherPairList);
+        CompletableFuture<List<Chunk>> normalFuture = getWorldChunk(Environment.NORMAL, pairList);
+
+        return CompletableFuture.allOf(endFuture, netherFuture, normalFuture)
+                .thenCompose(v -> scanChunk(Environment.THE_END, endFuture.join())
+                        .thenCompose(b -> scanChunk(Environment.NETHER, netherFuture.join()))
+                        .thenCompose(b2 -> scanChunk(Environment.NORMAL, normalFuture.join()))
+                        .thenApply(b3 -> !chunksToCheck.isEmpty()));
     }
 
     private void scanEntities() {
@@ -225,10 +224,7 @@ public class RecountCalculator {
     }
 
     public void tidyUp() {
-        if (ibc == null) {
-            ibc = new IslandBlockCount(island.getUniqueId(),
-                    addon.getPlugin().getIWM().getAddon(world).map(a -> a.getDescription().getName()).orElse("default"));
-        }
+        ibc = bll.getIsland(island);
         // Reset and write per-env block counts
         ibc.clearAllBlockCounts();
         results.getEnvBlockCount().forEach((env, multiset) -> multiset.forEach(key -> ibc.add(env, key)));

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -290,7 +290,11 @@ public class BlockLimitsListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBlock(BlockSpreadEvent e) {
-        process(e.getBlock(), true);
+        process(e.getBlock(), false);
+        if (process(e.getBlock(), e.getNewState().getBlockData(), true) > -1) {
+            e.setCancelled(true);
+            process(e.getBlock(), true);
+        }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -306,6 +310,7 @@ public class BlockLimitsListener implements Listener {
     public void onBlock(BlockGrowEvent e) {
         if (process(e.getNewState().getBlock(), true) > -1) {
             e.setCancelled(true);
+            process(e.getNewState().getBlock(), false);
             e.getBlock().getWorld().getBlockAt(e.getBlock().getLocation()).setBlockData(e.getBlock().getBlockData());
         } else {
             process(e.getBlock(), false);

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -310,7 +310,6 @@ public class BlockLimitsListener implements Listener {
     public void onBlock(BlockGrowEvent e) {
         if (process(e.getNewState().getBlock(), true) > -1) {
             e.setCancelled(true);
-            process(e.getNewState().getBlock(), false);
             e.getBlock().getWorld().getBlockAt(e.getBlock().getLocation()).setBlockData(e.getBlock().getBlockData());
         } else {
             process(e.getBlock(), false);

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -579,6 +579,9 @@ public class BlockLimitsListenerTest {
         Block block = mockBlock(Material.GRASS_BLOCK, blockLocation);
         Block source = mockBlock(Material.GRASS_BLOCK, new Location(world, 101, 65, 100));
         BlockState newState = mock(BlockState.class);
+        BlockData newBlockData = mock(BlockData.class);
+        when(newBlockData.getMaterial()).thenReturn(Material.GRASS_BLOCK);
+        when(newState.getBlockData()).thenReturn(newBlockData);
         BlockSpreadEvent event = new BlockSpreadEvent(block, source, newState);
 
         listener.onBlock(event);

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -591,6 +591,52 @@ public class BlockLimitsListenerTest {
         assertEquals(1, ibc.getBlockCount(Material.GRASS_BLOCK.getKey()));
     }
 
+    @Test
+    public void testBlockSpreadDecrementsOldAddsNew() {
+        // Grass spreading onto dirt: DIRT count should drop, GRASS_BLOCK count should rise.
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.add(Environment.NORMAL, Material.DIRT.getKey());
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.DIRT, blockLocation);
+        Block source = mockBlock(Material.GRASS_BLOCK, new Location(world, 101, 65, 100));
+        BlockState newState = mock(BlockState.class);
+        BlockData newBlockData = mock(BlockData.class);
+        when(newBlockData.getMaterial()).thenReturn(Material.GRASS_BLOCK);
+        when(newState.getBlockData()).thenReturn(newBlockData);
+        BlockSpreadEvent event = new BlockSpreadEvent(block, source, newState);
+
+        listener.onBlock(event);
+
+        assertFalse(event.isCancelled());
+        assertEquals(0, ibc.getBlockCount(Material.DIRT.getKey()));
+        assertEquals(1, ibc.getBlockCount(Material.GRASS_BLOCK.getKey()));
+    }
+
+    @Test
+    public void testBlockSpreadAtLimitCancelsAndRestoresOld() {
+        // GRASS_BLOCK is at limit; spread onto DIRT must be cancelled and the DIRT count preserved.
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.add(Environment.NORMAL, Material.DIRT.getKey());
+        ibc.setBlockLimit(Environment.NORMAL, Material.GRASS_BLOCK.getKey(), 1);
+        ibc.add(Environment.NORMAL, Material.GRASS_BLOCK.getKey());
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.DIRT, blockLocation);
+        Block source = mockBlock(Material.GRASS_BLOCK, new Location(world, 101, 65, 100));
+        BlockState newState = mock(BlockState.class);
+        BlockData newBlockData = mock(BlockData.class);
+        when(newBlockData.getMaterial()).thenReturn(Material.GRASS_BLOCK);
+        when(newState.getBlockData()).thenReturn(newBlockData);
+        BlockSpreadEvent event = new BlockSpreadEvent(block, source, newState);
+
+        listener.onBlock(event);
+
+        assertTrue(event.isCancelled());
+        assertEquals(1, ibc.getBlockCount(Material.DIRT.getKey()));
+        assertEquals(1, ibc.getBlockCount(Material.GRASS_BLOCK.getKey()));
+    }
+
     // --- BlockFromToEvent tests ---
 
     @Test
@@ -731,6 +777,32 @@ public class BlockLimitsListenerTest {
         assertEquals(1, ibc.getBlockCount(Material.DIRT.getKey()));
         assertEquals(0, ibc.getBlockCount(Material.GRASS_BLOCK.getKey()));
         verify(worldBlock).setBlockData(block.getBlockData());
+    }
+
+    @Test
+    public void testBlockGrowAtNonZeroLimitDoesNotDecrement() {
+        // GRASS_BLOCK is at a non-zero limit (5 of 5). A blocked grow must NOT change the count.
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.setBlockLimit(Environment.NORMAL, Material.GRASS_BLOCK.getKey(), 5);
+        for (int i = 0; i < 5; i++) {
+            ibc.add(Environment.NORMAL, Material.GRASS_BLOCK.getKey());
+        }
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.DIRT, blockLocation);
+        Block newBlock = mockBlock(Material.GRASS_BLOCK, blockLocation);
+        BlockState newState = mock(BlockState.class);
+        when(newState.getBlock()).thenReturn(newBlock);
+
+        Block worldBlock = mock(Block.class);
+        when(world.getBlockAt(blockLocation)).thenReturn(worldBlock);
+
+        BlockGrowEvent event = new BlockGrowEvent(block, newState);
+        listener.onBlock(event);
+
+        assertTrue(event.isCancelled());
+        // The physical world still has 5 grass blocks, so the count must remain 5.
+        assertEquals(5, ibc.getBlockCount(Material.GRASS_BLOCK.getKey()));
     }
 
     // --- EntityChangeBlockEvent state transition tests ---


### PR DESCRIPTION
Builds on @daniel-skopek's #263 — superseding it so the fix can land with the bug-2 correction and tests already applied. Daniel's original commit is preserved here with authorship intact; thanks for the catches. 🙏

## What this brings over from #263 (unchanged)

- **BlockSpreadEvent** now decrements the replaced block before adding the new one (previously it only incremented, permanently inflating counts for spread-overwritten materials). Mirrors the existing `BlockFormEvent` pattern.
- **RecountCalculator** loads all chunks within an environment — and all three environments — in parallel instead of sequentially, fixing the 5-minute `CALCULATION_TIMEOUT` that produced *no* result on large islands.
- **RecountCalculator** uses the `@NonNull getIsland(Island)` overload in the constructor and `tidyUp()`, so a recount no longer risks creating an empty `IslandBlockCount` that drops permission-based limits and offsets.

## What changed vs #263

The BlockGrowEvent handler in #263 added `process(e.getNewState().getBlock(), false)` after a cancelled (over-limit) grow. That decrement is unbalanced: `process(block, true)` returns **before** incrementing when the limit is hit, so the extra call removes a count that was never added. For a material at a non-zero limit, a blocked grow drove the stored count *below* the true physical count, then let the next grow slip past the limit.

This branch drops that one line (the cancel branch was already balanced) and adds tests:

- `testBlockSpreadDecrementsOldAddsNew` — confirms the spread leak fix
- `testBlockSpreadAtLimitCancelsAndRestoresOld` — confirms a clean revert when the new material is at limit
- `testBlockGrowAtNonZeroLimitDoesNotDecrement` — regression guard: a blocked grow at 5/5 leaves the count at 5

Full discussion and the empirical 5→4 repro are in the #263 review.

All 233 tests pass.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
