### PR TITLE
Anchor golem/snowman block removal on the pumpkin, not the spawn block (#127)

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -48,6 +48,8 @@ public class EntityLimitListener implements Listener {
     /** Cardinal directions used for block structure detection. */
     private static final List<BlockFace> CARDINALS = List.of(BlockFace.UP, BlockFace.NORTH, BlockFace.SOUTH,
             BlockFace.EAST, BlockFace.WEST, BlockFace.DOWN);
+    /** One block face per horizontal axis, used to find golem arms regardless of facing. */
+    private static final List<BlockFace> HORIZONTAL = List.of(BlockFace.NORTH, BlockFace.EAST);
 
     public EntityLimitListener(Limits addon) {
         this.addon = addon;
@@ -289,61 +291,70 @@ public class EntityLimitListener implements Listener {
     }
 
     private void detectIronGolem(Location location) {
-        Block legs = location.getBlock();
-        addon.getBlockLimitListener().removeBlock(legs);
-        legs.setType(Material.AIR);
-        for (BlockFace bf : CARDINALS) {
-            Block body = legs.getRelative(bf);
-            if (body.getType().equals(Material.IRON_BLOCK)) {
-                Block head = body.getRelative(bf);
-                if (isGolemHead(head) && eraseGolemIfArmsMatch(body, head, bf)) {
-                    return;
-                }
+        // Anchor on the carved pumpkin: body and base are the two iron blocks below it,
+        // arms are two opposite iron blocks beside the body on a horizontal axis.
+        Block head = findPumpkinHead(location, Material.IRON_BLOCK);
+        if (head == null) {
+            return;
+        }
+        Block body = head.getRelative(BlockFace.DOWN);
+        Block base = body.getRelative(BlockFace.DOWN);
+        if (base.getType() != Material.IRON_BLOCK) {
+            return;
+        }
+        for (BlockFace bf : HORIZONTAL) {
+            Block arm1 = body.getRelative(bf);
+            Block arm2 = body.getRelative(bf.getOppositeFace());
+            if (arm1.getType() == Material.IRON_BLOCK && arm2.getType() == Material.IRON_BLOCK) {
+                eraseBlocks(head, body, base, arm1, arm2);
+                return;
             }
         }
+    }
+
+    private void detectSnowman(Location location) {
+        // Anchor on the carved pumpkin: the two snow blocks below it are the body and base.
+        Block head = findPumpkinHead(location, Material.SNOW_BLOCK);
+        if (head == null) {
+            return;
+        }
+        Block body = head.getRelative(BlockFace.DOWN);
+        Block base = body.getRelative(BlockFace.DOWN);
+        if (base.getType() != Material.SNOW_BLOCK) {
+            return;
+        }
+        eraseBlocks(head, body, base);
+    }
+
+    /**
+     * Locate the carved pumpkin / jack o'lantern that tops a freshly built golem or snowman.
+     *
+     * <p>The {@link CreatureSpawnEvent} location for a built mob is not guaranteed to be a
+     * particular block of the structure, so we anchor on the unambiguous pumpkin rather than
+     * assuming the spawn block is the base. Scan the spawn block and the two blocks above it
+     * for a head that sits directly on top of the expected body material.
+     *
+     * @return the pumpkin block, or {@code null} if none is found
+     */
+    private Block findPumpkinHead(Location location, Material bodyMaterial) {
+        Block b = location.getBlock();
+        for (int i = 0; i < 3; i++) {
+            if (isGolemHead(b) && b.getRelative(BlockFace.DOWN).getType() == bodyMaterial) {
+                return b;
+            }
+            b = b.getRelative(BlockFace.UP);
+        }
+        return null;
     }
 
     private boolean isGolemHead(Block block) {
         return block.getType() == Material.CARVED_PUMPKIN || block.getType() == Material.JACK_O_LANTERN;
     }
 
-    private boolean eraseGolemIfArmsMatch(Block body, Block head, BlockFace bf) {
-        for (BlockFace bf2 : CARDINALS) {
-            Block arm1 = body.getRelative(bf2);
-            Block arm2 = body.getRelative(bf2.getOppositeFace());
-            if (arm1.getType() == Material.IRON_BLOCK && arm2.getType() == Material.IRON_BLOCK
-                    && arm1.getRelative(bf.getOppositeFace()).isEmpty()
-                    && arm2.getRelative(bf.getOppositeFace()).isEmpty()) {
-                addon.getBlockLimitListener().removeBlock(body);
-                addon.getBlockLimitListener().removeBlock(arm1);
-                addon.getBlockLimitListener().removeBlock(arm2);
-                addon.getBlockLimitListener().removeBlock(head);
-                body.setType(Material.AIR);
-                arm1.setType(Material.AIR);
-                arm2.setType(Material.AIR);
-                head.setType(Material.AIR);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void detectSnowman(Location location) {
-        Block legs = location.getBlock();
-        addon.getBlockLimitListener().removeBlock(legs);
-        legs.setType(Material.AIR);
-        for (BlockFace bf : CARDINALS) {
-            Block body = legs.getRelative(bf);
-            if (body.getType().equals(Material.SNOW_BLOCK)) {
-                Block head = body.getRelative(bf);
-                if (head.getType() == Material.CARVED_PUMPKIN || head.getType() == Material.JACK_O_LANTERN) {
-                    addon.getBlockLimitListener().removeBlock(body);
-                    addon.getBlockLimitListener().removeBlock(head);
-                    body.setType(Material.AIR);
-                    head.setType(Material.AIR);
-                    return;
-                }
-            }
+    private void eraseBlocks(Block... blocks) {
+        for (Block b : blocks) {
+            addon.getBlockLimitListener().removeBlock(b);
+            b.setType(Material.AIR);
         }
     }
 

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -11,8 +11,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -577,6 +580,104 @@ public class EntityLimitListenerTest {
         when(entity.getWorld()).thenReturn(world);
         when(entity.getUniqueId()).thenReturn(UUID.randomUUID());
         return entity;
+    }
+
+    // --- Golem / snowman block-removal tests (#127) ---
+
+    @Test
+    public void testDetectIronGolemRemovesAllBlocksWhenSpawnedAtBody() throws Exception {
+        grid = new HashMap<>();
+        Block base = setBlock(0, 64, 0, Material.IRON_BLOCK);
+        Block body = setBlock(0, 65, 0, Material.IRON_BLOCK);
+        Block head = setBlock(0, 66, 0, Material.CARVED_PUMPKIN);
+        Block arm1 = setBlock(0, 65, -1, Material.IRON_BLOCK); // NORTH
+        Block arm2 = setBlock(0, 65, 1, Material.IRON_BLOCK); // SOUTH
+
+        // Vanilla can spawn the golem at the BODY block; the old base-anchored search missed
+        // everything except the spawn block, leaving the base, arms and pumpkin behind (#127).
+        invokeDetect("detectIronGolem", spawnAt(body));
+
+        for (Block b : List.of(base, body, head, arm1, arm2)) {
+            verify(bll).removeBlock(b);
+            verify(b).setType(Material.AIR);
+        }
+    }
+
+    @Test
+    public void testDetectIronGolemRemovesAllBlocksWhenSpawnedAtBase() throws Exception {
+        grid = new HashMap<>();
+        Block base = setBlock(0, 64, 0, Material.IRON_BLOCK);
+        Block body = setBlock(0, 65, 0, Material.IRON_BLOCK);
+        Block head = setBlock(0, 66, 0, Material.CARVED_PUMPKIN);
+        Block arm1 = setBlock(1, 65, 0, Material.IRON_BLOCK); // EAST
+        Block arm2 = setBlock(-1, 65, 0, Material.IRON_BLOCK); // WEST
+
+        invokeDetect("detectIronGolem", spawnAt(base));
+
+        for (Block b : List.of(base, body, head, arm1, arm2)) {
+            verify(bll).removeBlock(b);
+            verify(b).setType(Material.AIR);
+        }
+    }
+
+    @Test
+    public void testDetectSnowmanRemovesAllBlocks() throws Exception {
+        grid = new HashMap<>();
+        Block base = setBlock(0, 64, 0, Material.SNOW_BLOCK);
+        Block body = setBlock(0, 65, 0, Material.SNOW_BLOCK);
+        Block head = setBlock(0, 66, 0, Material.JACK_O_LANTERN);
+
+        invokeDetect("detectSnowman", spawnAt(body));
+
+        for (Block b : List.of(base, body, head)) {
+            verify(bll).removeBlock(b);
+            verify(b).setType(Material.AIR);
+        }
+    }
+
+    @Test
+    public void testDetectIronGolemLeavesUnrelatedBlocksAlone() throws Exception {
+        grid = new HashMap<>();
+        // A lone iron block with no pumpkin is not a golem — nothing may be erased.
+        Block stray = setBlock(0, 65, 0, Material.IRON_BLOCK);
+
+        invokeDetect("detectIronGolem", spawnAt(stray));
+
+        verify(stray, never()).setType(Material.AIR);
+        verify(bll, never()).removeBlock(any(Block.class));
+    }
+
+    /** Coordinate-keyed mock blocks whose getRelative() walks the shared grid. */
+    private Map<List<Integer>, Block> grid;
+
+    private Block gridBlock(int x, int y, int z) {
+        return grid.computeIfAbsent(List.of(x, y, z), k -> {
+            Block b = mock(Block.class);
+            when(b.getType()).thenReturn(Material.AIR);
+            when(b.getRelative(any(BlockFace.class))).thenAnswer(inv -> {
+                BlockFace f = inv.getArgument(0);
+                return gridBlock(x + f.getModX(), y + f.getModY(), z + f.getModZ());
+            });
+            return b;
+        });
+    }
+
+    private Block setBlock(int x, int y, int z, Material type) {
+        Block b = gridBlock(x, y, z);
+        when(b.getType()).thenReturn(type);
+        return b;
+    }
+
+    private Location spawnAt(Block block) {
+        Location loc = mock(Location.class);
+        when(loc.getBlock()).thenReturn(block);
+        return loc;
+    }
+
+    private void invokeDetect(String method, Location loc) throws Exception {
+        Method m = EntityLimitListener.class.getDeclaredMethod(method, Location.class);
+        m.setAccessible(true);
+        m.invoke(ell, loc);
     }
 
 }


### PR DESCRIPTION
Fixes #127.

## The bug

With Limits installed, building an iron golem left the iron blocks and the jack o'lantern in the world instead of consuming them (reported with [video](https://www.youtube.com/watch?v=YzgzkNNAu9A); confirmed by multiple users that it only happens with Limits installed).

## Root cause

Built golems/snowmen are spawned via the async path (the `CreatureSpawnEvent` is cancelled and the mob is re-spawned), so Limits has to clear the building blocks itself in `detectIronGolem()`. That method assumed the spawn location was the **base** iron block and only searched **upward**:

```java
Block legs = location.getBlock();   // assumed BASE
...
for (BlockFace bf : CARDINALS) { Block body = legs.getRelative(bf); ... }
```

A built mob's `CreatureSpawnEvent` location is **not guaranteed** to be a particular block of the structure. When it's the **body** block, the upward search matches nothing — so only the spawn block was removed and the base, both arms, and the pumpkin were left behind. (The old code also unconditionally `setType(AIR)`'d the spawn block before matching anything.)

## Fix

Anchor detection on the **carved pumpkin / jack o'lantern**, which is unambiguous:

1. Scan the spawn block and the two blocks above it for the head sitting on the expected body material.
2. Verify body + base below it, and two opposite iron arms beside the body.
3. Erase the full set — **only if a complete valid pattern matches** (safer than the old unconditional removal).

This works whether the spawn anchors on the base, body, or head. Snowman detection is anchored the same way.

## Tests

A coordinate-keyed mock block grid drives four tests:
- iron golem removed when spawned at the **body** block (the #127 case),
- iron golem removed when spawned at the **base** block (robustness),
- snowman fully removed,
- a lone iron block with no pumpkin is left untouched.

The first three fail on the current code and pass with the fix. Full suite: **237 tests, 0 failures**.

## Scope note

This PR fixes the iron golem and snowman (both pumpkin-topped). `detectWither()` has the same base-anchored assumption and could be given the same treatment in a follow-up, but withers weren't part of this report and the rewrite is more involved, so it's left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
