### PR TITLE
Fix three entity counting bugs in EntityLimitListener

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -45,6 +45,10 @@ public class EntityLimitListener implements Listener {
     private final Limits addon;
     /** Entity UUIDs that have just spawned to prevent double-processing. */
     private final List<UUID> justSpawned = new ArrayList<>();
+    /** Entity UUIDs that are currently portaling to prevent double-decrement on cross-world removal. */
+    private final List<UUID> justPortaled = new ArrayList<>();
+    /** Maps entity UUID to island ID so decrement works even when the entity dies off-island. */
+    private final Map<UUID, String> entityIslandMap = new HashMap<>();
     /** Cardinal directions used for block structure detection. */
     private static final List<BlockFace> CARDINALS = List.of(BlockFace.UP, BlockFace.NORTH, BlockFace.SOUTH,
             BlockFace.EAST, BlockFace.WEST, BlockFace.DOWN);
@@ -118,7 +122,7 @@ public class EntityLimitListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBlock(HangingPlaceEvent hangingPlaceEvent) {
         if (!addon.inGameModeWorld(hangingPlaceEvent.getBlock().getWorld())) return;
         Player player = hangingPlaceEvent.getPlayer();
@@ -175,6 +179,7 @@ public class EntityLimitListener implements Listener {
                 .ifPresent(island -> {
                     IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island);
                     ibc.incrementEntity(envOf(w), entity.getType());
+                    entityIslandMap.put(entity.getUniqueId(), island.getUniqueId());
                 });
     }
 
@@ -189,6 +194,19 @@ public class EntityLimitListener implements Listener {
         Entity entity = e.getEntity();
         World w = entity.getWorld();
         if (!addon.inGameModeWorld(w)) return;
+
+        // Entity is being portaled — count transfer was already handled by onEntityPortal.
+        if (justPortaled.remove(entity.getUniqueId())) return;
+
+        String islandId = entityIslandMap.remove(entity.getUniqueId());
+        if (islandId != null) {
+            IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(islandId);
+            if (ibc != null) {
+                ibc.decrementEntity(envOf(w), entity.getType());
+            }
+            return;
+        }
+
         addon.getIslands().getIslandAt(entity.getLocation())
                 .filter(island -> !island.isSpawn())
                 .ifPresent(island -> {
@@ -214,8 +232,12 @@ public class EntityLimitListener implements Listener {
         if (fromEnv == toEnv) return;
         if (!addon.inGameModeWorld(fromWorld) && !addon.inGameModeWorld(toWorld)) return;
 
+        // Prevent onEntityRemove from double-decrementing for the source-world removal.
+        justPortaled.add(entity.getUniqueId());
+
         // Decrement at source if on a tracked island
         if (addon.inGameModeWorld(fromWorld)) {
+            entityIslandMap.remove(entity.getUniqueId());
             addon.getIslands().getIslandAt(entity.getLocation())
                     .filter(island -> !island.isSpawn())
                     .ifPresent(island -> {
@@ -232,6 +254,7 @@ public class EntityLimitListener implements Listener {
                     .ifPresent(island -> {
                         IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island);
                         ibc.incrementEntity(toEnv, entity.getType());
+                        entityIslandMap.put(entity.getUniqueId(), island.getUniqueId());
                     });
         }
     }
@@ -252,7 +275,9 @@ public class EntityLimitListener implements Listener {
     private boolean processIsland(Cancellable cancelableEvent, LivingEntity livingEntity, Location location,
             SpawnReason spawnReason, boolean runAsync) {
         if (addon.getIslands().getIslandAt(livingEntity.getLocation()).isEmpty()) {
-            cancelableEvent.setCancelled(false);
+            if (runAsync) {
+                cancelableEvent.setCancelled(false);
+            }
             return true;
         }
         Island island = addon.getIslands().getIslandAt(livingEntity.getLocation()).get();


### PR DESCRIPTION
## Summary

Fixes three bugs that could cause incorrect entity counts:
1. Counts drifting above reality when mobs die off-island (the most
   impactful for players)
2. A race condition in HangingPlaceEvent that could falsely increment
3. processIsland overriding other plugins' event cancellations

## Changes

### 1. Entity counts drifting above reality

trackSpawn counted the entity against the island where it spawned, but
onEntityRemove used getIslandAt(entity.getLocation()) — the entity's
**current** location. When a mob wandered outside island bounds and
died or despawned, getIslandAt returned empty and the count was never
decremented. Over time the limit would fill with nonexistent mobs.

**Fix:** Added an entityIslandMap (UUID → islandId) that remembers
which island each entity belongs to. trackSpawn populates it on
spawn, onEntityRemove uses it for decrement (falling back to
location-based lookup for pre-existing entities), and onEntityPortal
transfers the mapping for env-to-env teleports. A justPortaled
debounce list prevents double-decrement if EntityRemoveEvent fires
for the source-world removal during a portal.

### 2. HangingPlaceEvent handler ordering

onBlock (limit check) and onHangingPlaceTrack (increment) were both
registered at EventPriority.MONITOR. Bukkit does not guarantee handler
dispatch order at the same priority within a single class — if the
tracking handler ran first, the entity was counted before the limit
check could cancel the event.

**Fix:** Changed onBlock to EventPriority.LOW, consistent with
onCreatureSpawn and onMinecart. The MONITOR tracking handler now
always runs after the LOW limit check.

### 3. processIsland overriding other plugins' cancellations

processIsland called cancelableEvent.setCancelled(false)
unconditionally when the entity was not on a tracked island,
potentially reverting cancellations made by other plugins.

**Fix:** setCancelled(false) is now guarded by the existing runAsync
flag, which is only true for async golem/wither/snowman spawns where
this plugin itself pre-cancels the event.