### PR TITLE
Deny spawn-egg use before consumption when at the entity limit (#134)

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -14,8 +14,12 @@ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityRemoveEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.hanging.HangingPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.vehicle.VehicleCreateEvent;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -151,6 +155,87 @@ public class EntityLimitListener implements Listener {
                 }
             }
         });
+    }
+
+    /**
+     * Deny spawn-egg use the moment a player would exceed an entity limit, before the egg is
+     * consumed. The {@link CreatureSpawnEvent} path already cancels the over-limit spawn, but by
+     * then the egg item has been used up; cancelling the interaction here keeps the egg (#134).
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onSpawnEggUseOnBlock(PlayerInteractEvent e) {
+        if (e.getAction() != Action.RIGHT_CLICK_BLOCK || e.getClickedBlock() == null) {
+            return;
+        }
+        EntityType type = spawnEggType(e.getItem());
+        if (type != null) {
+            checkSpawnEggLimit(e, e.getPlayer(), e.getClickedBlock().getLocation(), type);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onSpawnEggUseOnEntity(PlayerInteractEntityEvent e) {
+        if (e.getHand() == null) {
+            return;
+        }
+        EntityType type = spawnEggType(e.getPlayer().getInventory().getItem(e.getHand()));
+        if (type != null) {
+            checkSpawnEggLimit(e, e.getPlayer(), e.getRightClicked().getLocation(), type);
+        }
+    }
+
+    private void checkSpawnEggLimit(Cancellable event, Player player, Location location, EntityType type) {
+        if (!addon.inGameModeWorld(location.getWorld())) {
+            return;
+        }
+        addon.getIslands().getIslandAt(location).ifPresent(island -> {
+            boolean bypass = player.isOp() || player.hasPermission(
+                    addon.getPlugin().getIWM().getPermissionPrefix(location.getWorld()) + MOD_BYPASS);
+            if (bypass || island.isSpawn()) {
+                return;
+            }
+            AtLimitResult res = atLimit(island, type, envOf(location.getWorld()));
+            if (res.hit()) {
+                event.setCancelled(true);
+                notifyEntityLimit(player, type, res);
+            }
+        });
+    }
+
+    /**
+     * Resolve the entity type a spawn-egg item would create, e.g. {@code PIG_SPAWN_EGG -> PIG}.
+     *
+     * @return the entity type, or {@code null} if the item is not a recognised spawn egg
+     */
+    private EntityType spawnEggType(ItemStack item) {
+        if (item == null) {
+            return null;
+        }
+        String name = item.getType().name();
+        if (!name.endsWith("_SPAWN_EGG")) {
+            return null;
+        }
+        try {
+            return EntityType.valueOf(name.substring(0, name.length() - "_SPAWN_EGG".length()));
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private void notifyEntityLimit(Player player, EntityType type, AtLimitResult res) {
+        if (res.getTypelimit() != null) {
+            User.getInstance(player).notify("entity-limits.hit-limit", "[entity]",
+                    Util.prettifyText(type.toString()), TextVariables.NUMBER,
+                    String.valueOf(res.getTypelimit().getValue()));
+        } else {
+            User.getInstance(player).notify("entity-limits.hit-limit", "[entity]",
+                    res.getGrouplimit().getKey().getName() + " ("
+                            + res.getGrouplimit().getKey().getTypes().stream()
+                                    .map(x -> Util.prettifyText(x.toString()))
+                                    .collect(Collectors.joining(", "))
+                            + ")",
+                    TextVariables.NUMBER, String.valueOf(res.getGrouplimit().getValue()));
+        }
     }
 
     /* =========================================================================
@@ -473,8 +558,10 @@ public class EntityLimitListener implements Listener {
      * for the entity's current environment.
      */
     AtLimitResult atLimit(Island island, Entity entity) {
-        Environment env = envOf(entity.getWorld());
-        EntityType type = entity.getType();
+        return atLimit(island, entity.getType(), envOf(entity.getWorld()));
+    }
+
+    AtLimitResult atLimit(Island island, EntityType type, Environment env) {
         @Nullable
         IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island.getUniqueId());
 

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -35,13 +35,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityBreedEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.hanging.HangingPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.vehicle.VehicleCreateEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -678,6 +683,76 @@ public class EntityLimitListenerTest {
         Method m = EntityLimitListener.class.getDeclaredMethod(method, Location.class);
         m.setAccessible(true);
         m.invoke(ell, loc);
+    }
+
+    // --- Spawn-egg interact guard tests (#134) ---
+
+    @Test
+    public void testSpawnEggOnEntityAtLimitIsCancelled() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ENDERMAN, 4); // seeded count is 4 -> at limit
+        Player p = eggPlayer(Material.ENDERMAN_SPAWN_EGG, EquipmentSlot.HAND);
+        Entity clicked = mock(Entity.class);
+        when(clicked.getLocation()).thenReturn(location);
+        PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(p, clicked, EquipmentSlot.HAND);
+
+        ell.onSpawnEggUseOnEntity(e);
+
+        // Cancelled before the egg is consumed, rather than only blocking the later spawn.
+        assertTrue(e.isCancelled());
+    }
+
+    @Test
+    public void testSpawnEggOnEntityUnderLimitNotCancelled() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ENDERMAN, 10); // count 4 < 10
+        Player p = eggPlayer(Material.ENDERMAN_SPAWN_EGG, EquipmentSlot.HAND);
+        Entity clicked = mock(Entity.class);
+        when(clicked.getLocation()).thenReturn(location);
+        PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(p, clicked, EquipmentSlot.HAND);
+
+        ell.onSpawnEggUseOnEntity(e);
+
+        assertFalse(e.isCancelled());
+    }
+
+    @Test
+    public void testNonSpawnEggOnEntityIgnored() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ENDERMAN, 4);
+        Player p = eggPlayer(Material.STICK, EquipmentSlot.HAND);
+        Entity clicked = mock(Entity.class);
+        when(clicked.getLocation()).thenReturn(location);
+        PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(p, clicked, EquipmentSlot.HAND);
+
+        ell.onSpawnEggUseOnEntity(e);
+
+        assertFalse(e.isCancelled());
+    }
+
+    @Test
+    public void testSpawnEggOnBlockAtLimitIsCancelled() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ENDERMAN, 4);
+        Player p = mock(Player.class);
+        when(p.isOp()).thenReturn(false);
+        when(p.hasPermission(anyString())).thenReturn(false);
+        when(p.getUniqueId()).thenReturn(UUID.randomUUID());
+        Block clicked = mock(Block.class);
+        when(clicked.getLocation()).thenReturn(location);
+        PlayerInteractEvent e = new PlayerInteractEvent(p, Action.RIGHT_CLICK_BLOCK,
+                new ItemStack(Material.ENDERMAN_SPAWN_EGG), clicked, BlockFace.UP);
+
+        ell.onSpawnEggUseOnBlock(e);
+
+        assertTrue(e.isCancelled());
+    }
+
+    private Player eggPlayer(Material item, EquipmentSlot hand) {
+        Player p = mock(Player.class);
+        when(p.isOp()).thenReturn(false);
+        when(p.hasPermission(anyString())).thenReturn(false);
+        when(p.getUniqueId()).thenReturn(UUID.randomUUID());
+        PlayerInventory inv = mock(PlayerInventory.class);
+        when(p.getInventory()).thenReturn(inv);
+        when(inv.getItem(hand)).thenReturn(new ItemStack(item));
+        return p;
     }
 
 }


### PR DESCRIPTION
Fixes #134.

## The bug

Using a spawn egg while at the entity limit consumes the egg but spawns nothing — and gives no message. Reported for right-clicking a mob with a spawn egg.

## Root cause

The only entity-limit check for egg spawns was on the resulting `CreatureSpawnEvent` (LOW priority). That correctly blocks the over-limit spawn, but the egg item has already been consumed by the time the spawn event fires, so the player simply loses the egg.

## Fix

Add two LOW-priority, pre-consumption guards:
- `PlayerInteractEvent` (spawn egg used on a block)
- `PlayerInteractEntityEvent` (spawn egg used on a mob — the reported case)

Each resolves the egg's entity type, checks the island's limit for that type up front, and cancels the interaction — keeping the egg and sending the `entity-limits.hit-limit` message — when the limit is hit. A spawn egg always produces its own type, so the egg material maps directly to the entity type checked (`PIG_SPAWN_EGG` → `PIG`); bypass perms and spawn islands are respected, matching the existing hanging-place handler.

`atLimit(Island, Entity)` is refactored to delegate to a new `atLimit(Island, EntityType, Environment)` overload so the limit can be evaluated without an entity instance.

## Tests

- egg on a mob at the limit → cancelled (egg kept),
- egg on a mob under the limit → allowed,
- non-spawn-egg item → ignored,
- egg on a block at the limit → cancelled.

Full suite: **239 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
