### PR TITLE
Evict entityIslandMap on chunk unload + tests for restart-drift fix

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -282,7 +282,7 @@ public class EntityLimitListener implements Listener {
      * {@link #trackSpawn} and are already in the map, so we skip them to
      * avoid an unnecessary {@code getIslandAt} lookup.
      */
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityAddToWorld(EntityAddToWorldEvent e) {
         Entity entity = e.getEntity();
         if (!(entity instanceof LivingEntity) && !(entity instanceof Vehicle)
@@ -307,9 +307,14 @@ public class EntityLimitListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityRemove(EntityRemoveEvent e) {
-        // Entities unloaded with their chunk are still alive — don't decrement.
-        if (e.getCause() == EntityRemoveEvent.Cause.UNLOAD) return;
         Entity entity = e.getEntity();
+        // Entities unloaded with their chunk are still alive — don't decrement. Drop the cached
+        // island mapping so it can't leak for entities that never load again; onEntityAddToWorld
+        // re-populates it on chunk reload.
+        if (e.getCause() == EntityRemoveEvent.Cause.UNLOAD) {
+            entityIslandMap.remove(entity.getUniqueId());
+            return;
+        }
         World w = entity.getWorld();
         if (!addon.inGameModeWorld(w)) return;
 

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -32,9 +32,11 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityBreedEvent;
+import org.bukkit.event.entity.EntityRemoveEvent;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.hanging.HangingPlaceEvent;
@@ -575,6 +577,110 @@ class EntityLimitListenerTest {
         ell.onCreatureSpawn(event);
 
         assertFalse(event.isCancelled());
+    }
+
+    // --- EntityAddToWorldEvent / restart-drift tests (#270) ---
+
+    @Test
+    void testEntityAddToWorldPopulatesMapForLoadedEntity() throws Exception {
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(enderman, world);
+
+        ell.onEntityAddToWorld(event);
+
+        assertEquals("test-island-id", entityIslandMap().get(enderman.getUniqueId()));
+    }
+
+    @Test
+    void testEntityAddToWorldIgnoresNonTrackedEntity() throws Exception {
+        // A projectile/item is neither LivingEntity, Vehicle nor Hanging — never mapped, no lookup.
+        Entity arrow = mock(Entity.class);
+        when(arrow.getUniqueId()).thenReturn(UUID.randomUUID());
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(arrow, world);
+
+        ell.onEntityAddToWorld(event);
+
+        assertTrue(entityIslandMap().isEmpty());
+        verify(islandsManager, never()).getIslandAt(any(Location.class));
+    }
+
+    @Test
+    void testEntityAddToWorldOutsideGameModeWorldIgnored() throws Exception {
+        when(addon.inGameModeWorld(world)).thenReturn(false);
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(enderman, world);
+
+        ell.onEntityAddToWorld(event);
+
+        assertTrue(entityIslandMap().isEmpty());
+    }
+
+    @Test
+    void testEntityAddToWorldOnSpawnIslandNotMapped() throws Exception {
+        when(island.isSpawn()).thenReturn(true);
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(enderman, world);
+
+        ell.onEntityAddToWorld(event);
+
+        assertTrue(entityIslandMap().isEmpty());
+    }
+
+    @Test
+    void testEntityAddToWorldSkipsAlreadyMappedEntity() throws Exception {
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        entityIslandMap().put(enderman.getUniqueId(), "existing-island");
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(enderman, world);
+
+        ell.onEntityAddToWorld(event);
+
+        // Mapping is untouched and no redundant getIslandAt lookup is performed.
+        assertEquals("existing-island", entityIslandMap().get(enderman.getUniqueId()));
+        verify(islandsManager, never()).getIslandAt(any(Location.class));
+    }
+
+    @Test
+    void testEntityRemoveUnloadEvictsMappingWithoutDecrement() throws Exception {
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        entityIslandMap().put(enderman.getUniqueId(), "test-island-id");
+        int before = ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN);
+
+        ell.onEntityRemove(new EntityRemoveEvent(enderman, EntityRemoveEvent.Cause.UNLOAD));
+
+        // Mapping dropped so it can't leak, but the count is untouched — the entity is still alive,
+        // just unloaded with its chunk; onEntityAddToWorld re-populates it on reload.
+        assertFalse(entityIslandMap().containsKey(enderman.getUniqueId()));
+        assertEquals(before, ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN));
+    }
+
+    @Test
+    void testReloadedEntityDecrementsWhenItDiesOffIsland() throws Exception {
+        // Simulate a restart: the in-memory map starts empty and the entity is reloaded from a chunk.
+        LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
+        ell.onEntityAddToWorld(new EntityAddToWorldEvent(enderman, world));
+        assertEquals("test-island-id", entityIslandMap().get(enderman.getUniqueId()));
+
+        int before = ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN);
+
+        // It wanders off the island and dies there, so getIslandAt no longer resolves an island.
+        Location offIsland = mock(Location.class);
+        when(offIsland.getWorld()).thenReturn(world);
+        when(islandsManager.getIslandAt(offIsland)).thenReturn(Optional.empty());
+        when(enderman.getLocation()).thenReturn(offIsland);
+
+        ell.onEntityRemove(new EntityRemoveEvent(enderman, EntityRemoveEvent.Cause.DEATH));
+
+        // The cached mapping lets the decrement happen even though the death was off-island —
+        // before #270 this entry was lost on restart and the count drifted upward.
+        assertEquals(before - 1, ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN));
+        assertFalse(entityIslandMap().containsKey(enderman.getUniqueId()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<UUID, String> entityIslandMap() throws Exception {
+        Field f = EntityLimitListener.class.getDeclaredField("entityIslandMap");
+        f.setAccessible(true);
+        return (Map<UUID, String>) f.get(ell);
     }
 
     // --- helper methods ---


### PR DESCRIPTION
Follow-up to #270 ("Fix entity counts drifting after server restart").

## Background
#270 added an `EntityAddToWorldEvent` handler that re-populates the in-memory `entityIslandMap` (entity UUID → island ID) when entities load from chunks, so off-island deaths still decrement counts after a restart.

## What this PR adds

**1. Evict on chunk unload (memory-leak fix).**
`onEntityRemove` returned early for `Cause.UNLOAD` without removing the entity from `entityIslandMap`. Before #270 only spawned-this-session entities leaked; #270 now maps *every* living entity/vehicle/hanging that loads on an island, so the map grew unbounded for entities that unload and never reload.

Now that `onEntityAddToWorld` rebuilds the entry on reload, it's safe to drop it on unload — which is exactly what was previously avoided (removing it would have lost the mapping permanently, the original bug). `onEntityRemove` now removes the UUID on `UNLOAD`.

**2. Drop a no-op annotation.**
`EntityAddToWorldEvent` is not `Cancellable`, so `ignoreCancelled = true` had no effect — removed.

**3. JUnit coverage** for the #270 handler and the new eviction:
- map population for loaded living entities
- non-tracked entity types, non-game-mode worlds, and spawn islands are skipped
- already-mapped entities are skipped without a redundant `getIslandAt` lookup
- `UNLOAD` evicts the mapping without decrementing the count
- a reloaded entity that dies **off-island** still decrements (regression test for the #270 bug)

## Testing
`mvn test` — 250 tests pass (7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)