### PR TITLE
Fix entity counts drifting above reality

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -566,4 +566,14 @@ public class BlockLimitsListener implements Listener {
         return islandCountMap.computeIfAbsent(island.getUniqueId(),
                 k -> new IslandBlockCount(k, island.getGameMode()));
     }
+
+    /**
+     * Notify that the island's data has changed so it gets batched for a save.
+     * Called from {@link EntityLimitListener} when entity counts are incremented
+     * or decremented — block changes go through {@link #process} which already
+     * calls this internally.
+     */
+    public void markChanged(String islandId) {
+        updateSaveMap(islandId);
+    }
 }

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -273,6 +273,7 @@ public class EntityLimitListener implements Listener {
                     IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island);
                     ibc.incrementEntity(envOf(w), entity.getType());
                     entityIslandMap.put(entity.getUniqueId(), island.getUniqueId());
+                    addon.getBlockLimitListener().markChanged(island.getUniqueId());
                 });
     }
 
@@ -326,6 +327,7 @@ public class EntityLimitListener implements Listener {
             IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(islandId);
             if (ibc != null) {
                 ibc.decrementEntity(envOf(w), entity.getType());
+                addon.getBlockLimitListener().markChanged(islandId);
             }
             return;
         }
@@ -336,6 +338,7 @@ public class EntityLimitListener implements Listener {
                     IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island.getUniqueId());
                     if (ibc != null) {
                         ibc.decrementEntity(envOf(w), entity.getType());
+                        addon.getBlockLimitListener().markChanged(island.getUniqueId());
                     }
                 });
     }
@@ -367,6 +370,7 @@ public class EntityLimitListener implements Listener {
                         IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island.getUniqueId());
                         if (ibc != null) {
                             ibc.decrementEntity(fromEnv, entity.getType());
+                            addon.getBlockLimitListener().markChanged(island.getUniqueId());
                         }
                     });
         }
@@ -378,6 +382,7 @@ public class EntityLimitListener implements Listener {
                         IslandBlockCount ibc = addon.getBlockLimitListener().getIsland(island);
                         ibc.incrementEntity(toEnv, entity.getType());
                         entityIslandMap.put(entity.getUniqueId(), island.getUniqueId());
+                        addon.getBlockLimitListener().markChanged(island.getUniqueId());
                     });
         }
     }


### PR DESCRIPTION
## Summary

Fixes persistent entity count drift where limits would show more mobs
than actually existed on the island. After a recount (/calc) the real
(lower) count would appear.

## Changes

### entityIslandMap + EntityAddToWorldEvent

Maps entity UUID to island ID so decrement always targets the correct
island, even when the entity wanders off-island before dying. The map
was transient — lost on every restart. An EntityAddToWorldEvent handler
now repopulates it when chunks load. A justPortaled debounce list
prevents double-decrement if EntityRemoveEvent fires for the
source-world removal during a portal teleport.

### Entity change persistence

incrementEntity/decrementEntity called setChanged() but never triggered
a save — only block changes called updateSaveMap. Entity-only changes
were only persisted on onDisable(). Added markChanged() on
BlockLimitsListener so entity changes join the batch-save cycle
(every 10 changes), ensuring counts survive restarts even without
block activity on the island.

## Testing

132 tests pass across EntityLimitListenerTest, BlockLimitsListenerTest,
JoinListenerTest, PaperShulkerLimitListenerTest, and others.