### PR TITLE
Quieten permission-limit join logging by default (#277)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.28.4</build.version>
+        <build.version>1.29.0</build.version>
         <sonar.projectKey>BentoBoxWorld_Limits</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -92,7 +92,7 @@ public class Settings {
         loadEntityLimits(addon, "entitylimits-end", List.of(Environment.THE_END));
 
         // Log limits on join
-        logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", true);
+        logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", false);
         // Async Golums
         asyncGolums = addon.getConfig().getBoolean("async-golums", true);
 

--- a/src/main/java/world/bentobox/limits/listeners/JoinListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/JoinListener.java
@@ -64,9 +64,14 @@ public class JoinListener implements Listener {
             islandBlockCount.clearAllEntityGroupLimits();
             islandBlockCount.clearAllBlockLimits();
         }
+        boolean bannerLogged = false;
         for (PermissionAttachmentInfo permissionInfo : player.getEffectivePermissions()) {
             if (!permissionInfo.getValue() || !permissionInfo.getPermission().startsWith(permissionPrefix)) {
                 continue;
+            }
+            if (!bannerLogged) {
+                logIfEnabled("Setting login limit via perm for " + player.getName() + "...");
+                bannerLogged = true;
             }
             islandBlockCount = applyOnePerm(player, permissionInfo, permissionPrefix, islandId, gameMode,
                     islandBlockCount);
@@ -93,7 +98,6 @@ public class JoinListener implements Listener {
         }
 
         IslandBlockCount ibc = current != null ? current : new IslandBlockCount(islandId, gameMode);
-        logIfEnabled("Setting login limit via perm for " + player.getName() + "...");
 
         LimitsPermCheckEvent limitsPermCheckEvent = new LimitsPermCheckEvent(player, islandId, ibc, entityGroup,
                 entityType, material, parsed.value);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,8 +24,9 @@ ignore-center-block: true
 # Cooldown for player recount command in seconds
 cooldown: 120
 
-# Log limits on join (to console)
-log-limits-on-join: true
+# Log limits on join (to console). Off by default - enable only for debugging as it
+# can be noisy for players who have many permission-based limits.
+log-limits-on-join: false
 
 # Use async checks for snowmen and iron golums. Set to false if you see problems.
 async-golums: true

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -94,8 +94,8 @@ class SettingsTest {
     }
 
     @Test
-    void testLogLimitsOnJoinDefaultsTrue() {
-        assertTrue(settings.isLogLimitsOnJoin());
+    void testLogLimitsOnJoinDefaultsFalse() {
+        assertFalse(settings.isLogLimitsOnJoin());
     }
 
     @Test


### PR DESCRIPTION
## Problem

Fixes #277. When a player with permission-based limits joins, `JoinListener` logs a `Setting login limit via perm for <player>...` banner for **every** matching permission, plus one line per environment (NORMAL/NETHER/THE_END). This logging is gated behind `log-limits-on-join`, but that setting **defaulted to `true`**, so every server saw this spam on each owner login.

## Changes

- **`config.yml` / `Settings.java`** — default `log-limits-on-join` to `false` and document it as a debug-only toggle. Servers that want the detail can still opt in.
- **`JoinListener.java`** — log the `Setting login limit via perm for...` banner **once per login** instead of once per matching permission, so it's much less noisy when the toggle is enabled.
- **`SettingsTest.java`** — updated the default-value test to expect `false`.
- **`pom.xml`** — bump to **1.29.0** (this changes default behaviour, so it's more than a bug fix).

## Testing

`SettingsTest` passes (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)