### PR TITLE
Cancel copper golem build when at COPPER_CHEST limit (#276)

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -477,6 +478,64 @@ public class BlockLimitsListener implements Listener {
             handler.saveObjectAsync(islandCountMap.get(id));
             saveMap.remove(id);
         }
+    }
+
+    /**
+     * The canonical copper chest material, or {@code null} on servers older than 1.21.9
+     * where copper chests (and copper golems) do not exist.
+     */
+    @Nullable
+    public Material getCopperChestMaterial() {
+        return COPPER_CHEST;
+    }
+
+    /**
+     * Read-only check of whether counting one more block of {@code key} on the island at
+     * {@code loc} would exceed the active limit. Used for blocks that appear without a
+     * place event — e.g. the copper chest a copper golem creates from a copper block, which
+     * fires no {@link BlockPlaceEvent} and so escapes the normal check (see
+     * <a href="https://github.com/BentoBoxWorld/Limits/issues/276">issue #276</a>).
+     *
+     * @return the limit value if already at/over it, otherwise -1
+     */
+    public int checkBlockLimit(Location loc, NamespacedKey key) {
+        World w = loc.getWorld();
+        if (w == null || !addon.inGameModeWorld(w)) {
+            return -1;
+        }
+        Environment env = envOf(w);
+        return addon.getIslands().getIslandAt(loc).map(i -> {
+            String id = i.getUniqueId();
+            String gameMode = addon.getGameModeName(w);
+            if (gameMode.isEmpty()) {
+                return -1;
+            }
+            islandCountMap.putIfAbsent(id, new IslandBlockCount(id, gameMode));
+            return checkLimit(w, env, key, id);
+        }).orElse(-1);
+    }
+
+    /**
+     * Unconditionally count one block of {@code key} against the island at {@code loc}.
+     * Mirror of {@link #removeBlock(Block)} for blocks that are created without a place
+     * event; the block really exists, so not counting it would let the count drift below
+     * reality (see <a href="https://github.com/BentoBoxWorld/Limits/issues/276">issue #276</a>).
+     */
+    public void addBlockCount(Location loc, NamespacedKey key) {
+        World w = loc.getWorld();
+        if (w == null || !addon.inGameModeWorld(w)) {
+            return;
+        }
+        addon.getIslands().getIslandAt(loc).ifPresent(i -> {
+            String id = i.getUniqueId();
+            String gameMode = addon.getGameModeName(w);
+            if (gameMode.isEmpty()) {
+                return;
+            }
+            Environment env = envOf(w);
+            islandCountMap.computeIfAbsent(id, k -> new IslandBlockCount(id, gameMode)).add(env, key);
+            updateSaveMap(id);
+        });
     }
 
     /**

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -51,6 +51,10 @@ public class EntityLimitListener implements Listener {
     private static final String ENTITY_LIMIT_HIT = "entity-limits.hit-limit";
     /** Notification placeholder for the entity name. */
     private static final String ENTITY_PLACEHOLDER = "[entity]";
+    /** Locale reference for the block limit notification. */
+    private static final String BLOCK_LIMIT_HIT = "block-limits.hit-limit";
+    /** Notification placeholder for the block material name. */
+    private static final String BLOCK_PLACEHOLDER = "[material]";
     private final Limits addon;
     /** Entity UUIDs that have just spawned to prevent double-processing. */
     private final List<UUID> justSpawned = new ArrayList<>();
@@ -155,11 +159,11 @@ public class EntityLimitListener implements Listener {
             if (res.hit()) {
                 hangingPlaceEvent.setCancelled(true);
                 if (res.getTypelimit() != null) {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(player).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             Util.prettifyText(hangingPlaceEvent.getEntity().getType().toString()),
                             TextVariables.NUMBER, String.valueOf(res.getTypelimit().getValue()));
                 } else {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(player).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             res.getGrouplimit().getKey().getName() + " ("
                                     + res.getGrouplimit().getKey().getTypes().stream()
                                             .map(x -> Util.prettifyText(x.toString()))
@@ -430,7 +434,7 @@ public class EntityLimitListener implements Listener {
             for (Entity ent : w.getNearbyEntities(location, 5, 5, 5)) {
                 if (ent instanceof Player p) {
                     p.updateInventory();
-                    User.getInstance(p).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(p).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             Util.prettifyText(material.toString()), TextVariables.NUMBER, String.valueOf(limit));
                 }
             }

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -123,6 +123,12 @@ public class EntityLimitListener implements Listener {
                         && creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BREEDING))) {
             return;
         }
+        // A copper golem turns its copper block into a copper chest with no place event,
+        // bypassing the COPPER_CHEST block limit (#276). Cancel the build if at that limit.
+        if (isBuildCopperGolem(creatureSpawnEvent.getSpawnReason())
+                && checkCopperChestLimit(creatureSpawnEvent)) {
+            return;
+        }
         if (creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BUILD_SNOWMAN)
                 || creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BUILD_IRONGOLEM)) {
             checkLimit(creatureSpawnEvent, creatureSpawnEvent.getEntity(), creatureSpawnEvent.getSpawnReason(),
@@ -251,6 +257,14 @@ public class EntityLimitListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCreatureSpawnTrack(final CreatureSpawnEvent e) {
         trackSpawn(e.getEntity());
+        // The copper block became a copper chest as part of the (uncancelled) build; count it
+        // so the COPPER_CHEST limit is enforceable and the count stays accurate (#276).
+        if (isBuildCopperGolem(e.getSpawnReason())) {
+            Material chest = addon.getBlockLimitListener().getCopperChestMaterial();
+            if (chest != null) {
+                addon.getBlockLimitListener().addBlockCount(e.getLocation(), chest.getKey());
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -372,6 +386,56 @@ public class EntityLimitListener implements Listener {
     /* =========================================================================
      * Limit-checking core
      * ========================================================================= */
+
+    /**
+     * Whether the spawn reason is a copper golem build. Matched by name so the addon links
+     * and runs on servers older than 1.21.9, where {@code BUILD_COPPERGOLEM} is absent.
+     */
+    private static boolean isBuildCopperGolem(SpawnReason reason) {
+        return reason.name().equals("BUILD_COPPERGOLEM");
+    }
+
+    /**
+     * When a copper golem is built its copper block is replaced by a copper chest without a
+     * {@link org.bukkit.event.block.BlockPlaceEvent}, so the {@code COPPER_CHEST} block limit
+     * is never checked. Cancel the build if the island is already at that limit (#276).
+     *
+     * @return true if the spawn was cancelled because the copper chest limit was hit
+     */
+    private boolean checkCopperChestLimit(CreatureSpawnEvent e) {
+        Material chest = addon.getBlockLimitListener().getCopperChestMaterial();
+        if (chest == null) {
+            return false;
+        }
+        Location loc = e.getLocation();
+        int limit = addon.getBlockLimitListener().checkBlockLimit(loc, chest.getKey());
+        if (limit < 0) {
+            return false;
+        }
+        e.setCancelled(true);
+        tellPlayersBlockLimit(loc, chest, limit);
+        return true;
+    }
+
+    /**
+     * Notify players near {@code location} that a block limit was hit, mirroring the block
+     * listener's own {@code block-limits.hit-limit} message.
+     */
+    private void tellPlayersBlockLimit(Location location, Material material, int limit) {
+        World w = location.getWorld();
+        if (w == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(addon.getPlugin(), () -> {
+            for (Entity ent : w.getNearbyEntities(location, 5, 5, 5)) {
+                if (ent instanceof Player p) {
+                    p.updateInventory();
+                    User.getInstance(p).notify("block-limits.hit-limit", "[material]",
+                            Util.prettifyText(material.toString()), TextVariables.NUMBER, String.valueOf(limit));
+                }
+            }
+        });
+    }
 
     private boolean checkLimit(Cancellable cancelableEvent, LivingEntity livingEntity, SpawnReason spawnReason,
             boolean runAsync) {

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -432,6 +432,51 @@ class EntityLimitListenerTest {
         assertFalse(event.isCancelled());
     }
 
+    // --- Copper golem / copper chest limit tests (#276) ---
+
+    @Test
+    void testCopperGolemAtChestLimitCancels() {
+        // Building a copper golem turns its copper block into a copper chest with no place
+        // event; the spawn must be cancelled when the COPPER_CHEST block limit is reached.
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        when(bll.checkBlockLimit(any(Location.class), any())).thenReturn(1);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawn(event);
+
+        assertTrue(event.isCancelled());
+        verify(bll).checkBlockLimit(location, Material.COPPER_CHEST.getKey());
+    }
+
+    @Test
+    void testCopperGolemUnderChestLimitNotCancelled() {
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        when(bll.checkBlockLimit(any(Location.class), any())).thenReturn(-1);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawn(event);
+
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    void testCopperGolemTrackCountsChest() {
+        // On a successful build the created copper chest must be counted so the limit is
+        // enforceable and the count does not drift below reality.
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawnTrack(event);
+
+        verify(bll).addBlockCount(location, Material.COPPER_CHEST.getKey());
+    }
+
     // --- VehicleCreateEvent tests ---
 
     @Test


### PR DESCRIPTION
Fixes #276.

## Problem

Building a copper golem (carved pumpkin on a copper block) replaces the copper block with a **copper chest** and spawns the golem. That block swap fires no `BlockPlaceEvent`, so the `COPPER_CHEST` block limit was never checked **and** the count was never incremented — players could build copper chests indefinitely past the configured limit.

## Fix

Handled on the `CreatureSpawnEvent` for `SpawnReason.BUILD_COPPERGOLEM` (matched by name so the addon still links/runs on servers older than 1.21.9):

- **LOW priority** — cancel the build and notify nearby players when the island is already at its `COPPER_CHEST` limit. The copper block and pumpkin are left untouched, consistent with existing iron golem / snowman / wither handling.
- **MONITOR priority** — on a successful (uncancelled) build, count the created copper chest so the limit stays enforceable and the count does not drift below reality.

Adds three small `BlockLimitsListener` helpers (`getCopperChestMaterial`, `checkBlockLimit`, `addBlockCount`) and tests for the at-limit, under-limit, and successful-build paths. Full suite: 259 tests, all green.

## Note for review

Option 1 (cancel the golem) matches the issue's stated expectation and the existing golem precedent. It relies on cancelling `BUILD_COPPERGOLEM` leaving the copper block un-transformed (the standard Bukkit contract, as with iron golems) — worth a quick in-game confirmation before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)