### PR TITLE
New Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.28.4</build.version>
+        <build.version>1.29.0</build.version>
         <sonar.projectKey>BentoBoxWorld_Limits</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -92,7 +92,7 @@ public class Settings {
         loadEntityLimits(addon, "entitylimits-end", List.of(Environment.THE_END));
 
         // Log limits on join
-        logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", true);
+        logLimitsOnJoin = addon.getConfig().getBoolean("log-limits-on-join", false);
         // Async Golums
         asyncGolums = addon.getConfig().getBoolean("async-golums", true);
 

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -472,6 +472,22 @@ public class BlockLimitsListener implements Listener {
      *
      * @return limit amount if at/over the limit (nothing was counted), or -1 on success
      */
+    /**
+     * True when the config ignores the island's center block and {@code loc} is that
+     * block. Compares block coordinates so entity locations (fractional coordinates,
+     * yaw/pitch) are matched correctly.
+     */
+    private boolean isIgnoredCenterBlock(Island island, Location loc) {
+        if (!addon.getConfig().getBoolean("ignore-center-block", true)) {
+            return false;
+        }
+        Location center = island.getCenter();
+        return center != null && Objects.equals(center.getWorld(), loc.getWorld())
+                && center.getBlockX() == loc.getBlockX()
+                && center.getBlockY() == loc.getBlockY()
+                && center.getBlockZ() == loc.getBlockZ();
+    }
+
     public int processKey(World world, Location location, NamespacedKey key, boolean add) {
         if (!addon.inGameModeWorld(world)) {
             return -1;
@@ -483,8 +499,7 @@ public class BlockLimitsListener implements Listener {
             if (gameMode.isEmpty()) {
                 return -1;
             }
-            if (addon.getConfig().getBoolean("ignore-center-block", true)
-                    && i.getCenter().equals(location)) {
+            if (isIgnoredCenterBlock(i, location)) {
                 return -1;
             }
             islandCountMap.putIfAbsent(id, new IslandBlockCount(id, gameMode));
@@ -551,7 +566,7 @@ public class BlockLimitsListener implements Listener {
         return addon.getIslands().getIslandAt(loc).map(i -> {
             String id = i.getUniqueId();
             String gameMode = addon.getGameModeName(w);
-            if (gameMode.isEmpty()) {
+            if (gameMode.isEmpty() || isIgnoredCenterBlock(i, loc)) {
                 return -1;
             }
             islandCountMap.putIfAbsent(id, new IslandBlockCount(id, gameMode));
@@ -573,7 +588,7 @@ public class BlockLimitsListener implements Listener {
         addon.getIslands().getIslandAt(loc).ifPresent(i -> {
             String id = i.getUniqueId();
             String gameMode = addon.getGameModeName(w);
-            if (gameMode.isEmpty()) {
+            if (gameMode.isEmpty() || isIgnoredCenterBlock(i, loc)) {
                 return;
             }
             Environment env = envOf(w);

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -477,6 +478,64 @@ public class BlockLimitsListener implements Listener {
             handler.saveObjectAsync(islandCountMap.get(id));
             saveMap.remove(id);
         }
+    }
+
+    /**
+     * The canonical copper chest material, or {@code null} on servers older than 1.21.9
+     * where copper chests (and copper golems) do not exist.
+     */
+    @Nullable
+    public Material getCopperChestMaterial() {
+        return COPPER_CHEST;
+    }
+
+    /**
+     * Read-only check of whether counting one more block of {@code key} on the island at
+     * {@code loc} would exceed the active limit. Used for blocks that appear without a
+     * place event — e.g. the copper chest a copper golem creates from a copper block, which
+     * fires no {@link BlockPlaceEvent} and so escapes the normal check (see
+     * <a href="https://github.com/BentoBoxWorld/Limits/issues/276">issue #276</a>).
+     *
+     * @return the limit value if already at/over it, otherwise -1
+     */
+    public int checkBlockLimit(Location loc, NamespacedKey key) {
+        World w = loc.getWorld();
+        if (w == null || !addon.inGameModeWorld(w)) {
+            return -1;
+        }
+        Environment env = envOf(w);
+        return addon.getIslands().getIslandAt(loc).map(i -> {
+            String id = i.getUniqueId();
+            String gameMode = addon.getGameModeName(w);
+            if (gameMode.isEmpty()) {
+                return -1;
+            }
+            islandCountMap.putIfAbsent(id, new IslandBlockCount(id, gameMode));
+            return checkLimit(w, env, key, id);
+        }).orElse(-1);
+    }
+
+    /**
+     * Unconditionally count one block of {@code key} against the island at {@code loc}.
+     * Mirror of {@link #removeBlock(Block)} for blocks that are created without a place
+     * event; the block really exists, so not counting it would let the count drift below
+     * reality (see <a href="https://github.com/BentoBoxWorld/Limits/issues/276">issue #276</a>).
+     */
+    public void addBlockCount(Location loc, NamespacedKey key) {
+        World w = loc.getWorld();
+        if (w == null || !addon.inGameModeWorld(w)) {
+            return;
+        }
+        addon.getIslands().getIslandAt(loc).ifPresent(i -> {
+            String id = i.getUniqueId();
+            String gameMode = addon.getGameModeName(w);
+            if (gameMode.isEmpty()) {
+                return;
+            }
+            Environment env = envOf(w);
+            islandCountMap.computeIfAbsent(id, k -> new IslandBlockCount(id, gameMode)).add(env, key);
+            updateSaveMap(id);
+        });
     }
 
     /**

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -51,6 +51,10 @@ public class EntityLimitListener implements Listener {
     private static final String ENTITY_LIMIT_HIT = "entity-limits.hit-limit";
     /** Notification placeholder for the entity name. */
     private static final String ENTITY_PLACEHOLDER = "[entity]";
+    /** Locale reference for the block limit notification. */
+    private static final String BLOCK_LIMIT_HIT = "block-limits.hit-limit";
+    /** Notification placeholder for the block material name. */
+    private static final String BLOCK_PLACEHOLDER = "[material]";
     private final Limits addon;
     /** Entity UUIDs that have just spawned to prevent double-processing. */
     private final List<UUID> justSpawned = new ArrayList<>();
@@ -155,11 +159,11 @@ public class EntityLimitListener implements Listener {
             if (res.hit()) {
                 hangingPlaceEvent.setCancelled(true);
                 if (res.getTypelimit() != null) {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(player).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             Util.prettifyText(hangingPlaceEvent.getEntity().getType().toString()),
                             TextVariables.NUMBER, String.valueOf(res.getTypelimit().getValue()));
                 } else {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(player).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             res.getGrouplimit().getKey().getName() + " ("
                                     + res.getGrouplimit().getKey().getTypes().stream()
                                             .map(x -> Util.prettifyText(x.toString()))
@@ -430,7 +434,7 @@ public class EntityLimitListener implements Listener {
             for (Entity ent : w.getNearbyEntities(location, 5, 5, 5)) {
                 if (ent instanceof Player p) {
                     p.updateInventory();
-                    User.getInstance(p).notify("block-limits.hit-limit", "[material]",
+                    User.getInstance(p).notify(BLOCK_LIMIT_HIT, BLOCK_PLACEHOLDER,
                             Util.prettifyText(material.toString()), TextVariables.NUMBER, String.valueOf(limit));
                 }
             }

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -123,6 +123,12 @@ public class EntityLimitListener implements Listener {
                         && creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BREEDING))) {
             return;
         }
+        // A copper golem turns its copper block into a copper chest with no place event,
+        // bypassing the COPPER_CHEST block limit (#276). Cancel the build if at that limit.
+        if (isBuildCopperGolem(creatureSpawnEvent.getSpawnReason())
+                && checkCopperChestLimit(creatureSpawnEvent)) {
+            return;
+        }
         if (creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BUILD_SNOWMAN)
                 || creatureSpawnEvent.getSpawnReason().equals(SpawnReason.BUILD_IRONGOLEM)) {
             checkLimit(creatureSpawnEvent, creatureSpawnEvent.getEntity(), creatureSpawnEvent.getSpawnReason(),
@@ -251,6 +257,14 @@ public class EntityLimitListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCreatureSpawnTrack(final CreatureSpawnEvent e) {
         trackSpawn(e.getEntity());
+        // The copper block became a copper chest as part of the (uncancelled) build; count it
+        // so the COPPER_CHEST limit is enforceable and the count stays accurate (#276).
+        if (isBuildCopperGolem(e.getSpawnReason())) {
+            Material chest = addon.getBlockLimitListener().getCopperChestMaterial();
+            if (chest != null) {
+                addon.getBlockLimitListener().addBlockCount(e.getLocation(), chest.getKey());
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -372,6 +386,56 @@ public class EntityLimitListener implements Listener {
     /* =========================================================================
      * Limit-checking core
      * ========================================================================= */
+
+    /**
+     * Whether the spawn reason is a copper golem build. Matched by name so the addon links
+     * and runs on servers older than 1.21.9, where {@code BUILD_COPPERGOLEM} is absent.
+     */
+    private static boolean isBuildCopperGolem(SpawnReason reason) {
+        return reason.name().equals("BUILD_COPPERGOLEM");
+    }
+
+    /**
+     * When a copper golem is built its copper block is replaced by a copper chest without a
+     * {@link org.bukkit.event.block.BlockPlaceEvent}, so the {@code COPPER_CHEST} block limit
+     * is never checked. Cancel the build if the island is already at that limit (#276).
+     *
+     * @return true if the spawn was cancelled because the copper chest limit was hit
+     */
+    private boolean checkCopperChestLimit(CreatureSpawnEvent e) {
+        Material chest = addon.getBlockLimitListener().getCopperChestMaterial();
+        if (chest == null) {
+            return false;
+        }
+        Location loc = e.getLocation();
+        int limit = addon.getBlockLimitListener().checkBlockLimit(loc, chest.getKey());
+        if (limit < 0) {
+            return false;
+        }
+        e.setCancelled(true);
+        tellPlayersBlockLimit(loc, chest, limit);
+        return true;
+    }
+
+    /**
+     * Notify players near {@code location} that a block limit was hit, mirroring the block
+     * listener's own {@code block-limits.hit-limit} message.
+     */
+    private void tellPlayersBlockLimit(Location location, Material material, int limit) {
+        World w = location.getWorld();
+        if (w == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(addon.getPlugin(), () -> {
+            for (Entity ent : w.getNearbyEntities(location, 5, 5, 5)) {
+                if (ent instanceof Player p) {
+                    p.updateInventory();
+                    User.getInstance(p).notify("block-limits.hit-limit", "[material]",
+                            Util.prettifyText(material.toString()), TextVariables.NUMBER, String.valueOf(limit));
+                }
+            }
+        });
+    }
 
     private boolean checkLimit(Cancellable cancelableEvent, LivingEntity livingEntity, SpawnReason spawnReason,
             boolean runAsync) {

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -59,8 +59,6 @@ public class EntityLimitListener implements Listener {
     private final Limits addon;
     /** Entity UUIDs that have just spawned to prevent double-processing. */
     private final List<UUID> justSpawned = new ArrayList<>();
-    /** Entity UUIDs that are currently portaling to prevent double-decrement on cross-world removal. */
-    private final List<UUID> justPortaled = new ArrayList<>();
     /** Maps entity UUID to island ID so decrement works even when the entity dies off-island. */
     private final Map<UUID, String> entityIslandMap = new HashMap<>();
     /** Cardinal directions used for block structure detection. */
@@ -344,9 +342,6 @@ public class EntityLimitListener implements Listener {
         World w = entity.getWorld();
         if (!addon.inGameModeWorld(w)) return;
 
-        // Entity is being portaled — count transfer was already handled by onEntityPortal.
-        if (justPortaled.remove(entity.getUniqueId())) return;
-
         String islandId = entityIslandMap.remove(entity.getUniqueId());
         if (islandId != null) {
             addon.getBlockLimitListener().decrementEntity(islandId, envOf(w), entity.getType());
@@ -374,8 +369,9 @@ public class EntityLimitListener implements Listener {
         if (fromEnv == toEnv) return;
         if (!addon.inGameModeWorld(fromWorld) && !addon.inGameModeWorld(toWorld)) return;
 
-        // Prevent onEntityRemove from double-decrementing for the source-world removal.
-        justPortaled.add(entity.getUniqueId());
+        // No EntityRemoveEvent guard is needed here: Paper suppresses the event for
+        // dimension changes (RemovalReason.CHANGED_DIMENSION carries a null Bukkit cause),
+        // so the source-world removal never reaches onEntityRemove.
 
         // Decrement at source if on a tracked island
         if (addon.inGameModeWorld(fromWorld)) {

--- a/src/main/java/world/bentobox/limits/listeners/JoinListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/JoinListener.java
@@ -64,9 +64,14 @@ public class JoinListener implements Listener {
             islandBlockCount.clearAllEntityGroupLimits();
             islandBlockCount.clearAllBlockLimits();
         }
+        boolean bannerLogged = false;
         for (PermissionAttachmentInfo permissionInfo : player.getEffectivePermissions()) {
             if (!permissionInfo.getValue() || !permissionInfo.getPermission().startsWith(permissionPrefix)) {
                 continue;
+            }
+            if (!bannerLogged) {
+                logIfEnabled("Setting login limit via perm for " + player.getName() + "...");
+                bannerLogged = true;
             }
             islandBlockCount = applyOnePerm(player, permissionInfo, permissionPrefix, islandId, gameMode,
                     islandBlockCount);
@@ -93,7 +98,6 @@ public class JoinListener implements Listener {
         }
 
         IslandBlockCount ibc = current != null ? current : new IslandBlockCount(islandId, gameMode);
-        logIfEnabled("Setting login limit via perm for " + player.getName() + "...");
 
         LimitsPermCheckEvent limitsPermCheckEvent = new LimitsPermCheckEvent(player, islandId, ibc, entityGroup,
                 entityType, material, parsed.value);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,7 +25,7 @@ ignore-center-block: true
 cooldown: 120
 
 # Log limits on join (to console). Off by default - enable only for debugging as it
-# can be noisy for players who have many permission-based limits.
+# can be noisy in console logs for servers with many permission-based limits.
 log-limits-on-join: false
 
 # Use async checks for snowmen and iron golums. Set to false if you see problems.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,8 +24,9 @@ ignore-center-block: true
 # Cooldown for player recount command in seconds
 cooldown: 120
 
-# Log limits on join (to console)
-log-limits-on-join: true
+# Log limits on join (to console). Off by default - enable only for debugging as it
+# can be noisy for players who have many permission-based limits.
+log-limits-on-join: false
 
 # Use async checks for snowmen and iron golums. Set to false if you see problems.
 async-golums: true

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -94,8 +94,8 @@ class SettingsTest {
     }
 
     @Test
-    void testLogLimitsOnJoinDefaultsTrue() {
-        assertTrue(settings.isLogLimitsOnJoin());
+    void testLogLimitsOnJoinDefaultsFalse() {
+        assertFalse(settings.isLogLimitsOnJoin());
     }
 
     @Test

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -1097,6 +1097,35 @@ class BlockLimitsListenerTest {
         assertTrue(event.isCancelled());
     }
 
+    // --- Center-block exclusion for the no-place-event helpers (#276 review) ---
+
+    @Test
+    void testCheckBlockLimitIgnoresCenterBlock() {
+        // At the limit everywhere else, but the location is the island center block
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.setBlockLimit(Environment.NORMAL, Material.CHEST.getKey(), 0);
+        listener.setIsland("test-island-id", ibc);
+
+        // Entity-style location inside the center block (fractional coordinates)
+        Location entityLoc = new Location(world, 0.5, 65.0, 0.3);
+        assertEquals(-1, listener.checkBlockLimit(entityLoc, Material.CHEST.getKey()));
+        // Away from the center the limit applies
+        assertEquals(0, listener.checkBlockLimit(blockLocation, Material.CHEST.getKey()));
+    }
+
+    @Test
+    void testAddBlockCountIgnoresCenterBlock() {
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        listener.setIsland("test-island-id", ibc);
+
+        Location entityLoc = new Location(world, 0.5, 65.0, 0.3);
+        listener.addBlockCount(entityLoc, Material.CHEST.getKey());
+        assertEquals(0, listener.getIsland("test-island-id").getBlockCount(Material.CHEST.getKey()));
+
+        listener.addBlockCount(blockLocation, Material.CHEST.getKey());
+        assertEquals(1, listener.getIsland("test-island-id").getBlockCount(Material.CHEST.getKey()));
+    }
+
     // --- Custom block keys (#176) ---
 
     @Test

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -432,6 +432,51 @@ class EntityLimitListenerTest {
         assertFalse(event.isCancelled());
     }
 
+    // --- Copper golem / copper chest limit tests (#276) ---
+
+    @Test
+    void testCopperGolemAtChestLimitCancels() {
+        // Building a copper golem turns its copper block into a copper chest with no place
+        // event; the spawn must be cancelled when the COPPER_CHEST block limit is reached.
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        when(bll.checkBlockLimit(any(Location.class), any())).thenReturn(1);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawn(event);
+
+        assertTrue(event.isCancelled());
+        verify(bll).checkBlockLimit(location, Material.COPPER_CHEST.getKey());
+    }
+
+    @Test
+    void testCopperGolemUnderChestLimitNotCancelled() {
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        when(bll.checkBlockLimit(any(Location.class), any())).thenReturn(-1);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawn(event);
+
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    void testCopperGolemTrackCountsChest() {
+        // On a successful build the created copper chest must be counted so the limit is
+        // enforceable and the count does not drift below reality.
+        when(bll.getCopperChestMaterial()).thenReturn(Material.COPPER_CHEST);
+        LivingEntity golem = mockEntity(EntityType.COPPER_GOLEM, location);
+
+        CreatureSpawnEvent event = new CreatureSpawnEvent(golem, SpawnReason.BUILD_COPPERGOLEM);
+
+        ell.onCreatureSpawnTrack(event);
+
+        verify(bll).addBlockCount(location, Material.COPPER_CHEST.getKey());
+    }
+
     // --- VehicleCreateEvent tests ---
 
     @Test

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -37,6 +37,7 @@ import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityBreedEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityRemoveEvent;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
@@ -801,6 +802,74 @@ class EntityLimitListenerTest {
         // before #270 this entry was lost on restart and the count drifted upward.
         assertEquals(before - 1, ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN));
         assertFalse(entityIslandMap().containsKey(enderman.getUniqueId()));
+    }
+
+    // --- EntityPortalEvent / phantom-count tests ---
+
+    @Test
+    void testEntityPortalTransfersCountBetweenEnvironments() throws Exception {
+        Location netherLoc = mockNetherLocation();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NORMAL, EntityType.CHICKEN));
+        assertEquals(1, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+        assertEquals("test-island-id", entityIslandMap().get(chicken.getUniqueId()));
+    }
+
+    @Test
+    void testPortaledEntityDeathStillDecrements() throws Exception {
+        // Regression: Paper never fires an EntityRemoveEvent for the dimension change itself
+        // (RemovalReason.CHANGED_DIMENSION has a null Bukkit cause), so the old justPortaled
+        // guard was never consumed and instead swallowed the entity's real death decrement,
+        // leaving a phantom count in the destination environment.
+        Location netherLoc = mockNetherLocation();
+        World nether = netherLoc.getWorld();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+        assertEquals(1, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+
+        // The entity now lives in the nether and dies there.
+        when(chicken.getWorld()).thenReturn(nether);
+        when(chicken.getLocation()).thenReturn(netherLoc);
+        ell.onEntityRemove(new EntityRemoveEvent(chicken, EntityRemoveEvent.Cause.DEATH));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+        assertFalse(entityIslandMap().containsKey(chicken.getUniqueId()));
+    }
+
+    @Test
+    void testRoundTripPortalThenDeathLeavesNoPhantomCount() throws Exception {
+        // The reported symptom: a mob portals to the nether, comes back, and dies in the
+        // overworld — the overworld count must return to zero, not stick at a phantom 1.
+        Location netherLoc = mockNetherLocation();
+        World nether = netherLoc.getWorld();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+        when(chicken.getWorld()).thenReturn(nether);
+        when(chicken.getLocation()).thenReturn(netherLoc);
+        ell.onEntityPortal(new EntityPortalEvent(chicken, netherLoc, location));
+        when(chicken.getWorld()).thenReturn(world);
+        when(chicken.getLocation()).thenReturn(location);
+
+        ell.onEntityRemove(new EntityRemoveEvent(chicken, EntityRemoveEvent.Cause.DEATH));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NORMAL, EntityType.CHICKEN));
+        assertEquals(0, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+    }
+
+    private Location mockNetherLocation() {
+        World nether = mock(World.class);
+        when(nether.getEnvironment()).thenReturn(Environment.NETHER);
+        when(addon.inGameModeWorld(nether)).thenReturn(true);
+        Location netherLoc = mock(Location.class);
+        when(netherLoc.getWorld()).thenReturn(nether);
+        return netherLoc;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Release PR for **Limits 1.29.0** (bumps `build.version` from 1.28.4).

## Added by this PR (develop → master)

- **Copper golem chest limit** (#276): building a copper golem converts a copper block into a copper chest without a place event, which bypassed the `COPPER_CHEST` block limit. The build is now cancelled when the island is at that limit, and the chest is counted when the build proceeds. Matched by spawn-reason name so the addon still runs on servers older than 1.21.9.
- **Quiet join logging by default** (#277): `log-limits-on-join` now defaults to `false`, and when enabled the per-permission log spam is reduced to a single banner per join.

## Also new since 1.28.4 (already merged to master, released with this)

- **Item frames, glow item frames, and paintings can be limited** (#66) — the persistent event-driven counting made them trackable.
- **Block group limits** (#12) — `blockgrouplimits` config section: one shared limit across a set of materials, with per-environment overrides. Closes the grass→dirt and piston/sticky-piston limit bypasses (#84, #132).
- **Team member limit permissions** (#241, opt-in) — `apply-member-limit-perms` merges team members' `island.limit.*` permissions into the island's limits, highest value wins.
- **ItemsAdder / Oraxen custom block limits** (#176) — custom ids go directly into `blocklimits` (ItemsAdder ids as-is, Oraxen ids as `oraxen:<id>`); enforcement via the plugins' own place/break events. *Needs in-game verification with the real plugins — test plan in #288.*
- **Reached-limits placeholders and API** (#2) — `%Limits_<gm>_island_reached_limits%` (+ per-env variants) and `Limits#getReachedLimits(...)`.
- **Stackable plants as one** (#53, opt-in) — `stacked-plants-count-as-one` counts a sugar cane / bamboo column as a single plant.
- **Locale name translations** (#188) — optional `island.limits.materials.*` / `entities.*` locale sections for GUI and hit-limit message names.
- **Limit message toggle** (#65) — `show-limit-messages: false` enforces limits silently.

## New config options (all defaults preserve existing behaviour except where noted)

| Option | Default | Notes |
|---|---|---|
| `show-limit-messages` | `true` | |
| `apply-member-limit-perms` | `false` | |
| `stacked-plants-count-as-one` | `false` | recount after changing |
| `blockgrouplimits` (+`-nether`/`-end`) | unset | recount after adding a group |
| `log-limits-on-join` | `false` | **changed** from `true` |

Custom block ids may now appear as quoted keys in any `blocklimits` section.

## Verification

295 JUnit tests pass on the merged branch. Merge conflicts between develop and master were reconciled so that #277's once-per-join banner applies to the refactored perm-merge loop, and #276's notification respects `show-limit-messages` and the locale name translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB