### PR TITLE
Allow item frames, glow item frames, and paintings to be limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ Some items cannot be limited (right now). The reasons are usually because there 
 * Ender crystals
 * Ender pearls
 * Ender dragon
-* Item frames
-* Paintings
+
+Item frames, glow item frames, and paintings **can** be limited: add `ITEM_FRAME`, `GLOW_ITEM_FRAME`, or `PAINTING` to the `entitylimits` section.

--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -70,9 +70,7 @@ public class Settings {
             EntityType.LEASH_KNOT,
             EntityType.GIANT,
             EntityType.ENDER_PEARL,
-            EntityType.ENDER_DRAGON,
-            EntityType.ITEM_FRAME,
-            EntityType.PAINTING);
+            EntityType.ENDER_DRAGON);
 
     public Settings(Limits addon) {
 

--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -23,6 +23,7 @@ import org.bukkit.World.Environment;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Slab;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Hanging;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -212,10 +213,9 @@ public class RecountCalculator {
             World w = e.getValue();
             for (Entity entity : w.getEntities()) {
                 if (!island.inIslandSpace(entity.getLocation())) continue;
-                if (entity instanceof LivingEntity || entity.getType().name().endsWith("_MINECART")
-                        || entity.getType().name().equals("ARMOR_STAND")
-                        || entity.getType().name().equals("ITEM_FRAME")
-                        || entity.getType().name().equals("PAINTING")) {
+                if (entity instanceof LivingEntity || entity instanceof Hanging
+                        || entity.getType().name().endsWith("_MINECART")
+                        || entity.getType().name().equals("ARMOR_STAND")) {
                     results.getEntityCount(env).add(entity.getType());
                 }
             }

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -140,6 +140,18 @@ class SettingsTest {
     }
 
     @Test
+    void testHangingEntityLimitsParsed() {
+        config.set("entitylimits.ITEM_FRAME", 10);
+        config.set("entitylimits.GLOW_ITEM_FRAME", 5);
+        config.set("entitylimits.PAINTING", 3);
+        Settings s = new Settings(addon);
+        Map<EntityType, Integer> limits = s.getLimits(Environment.NORMAL);
+        assertEquals(10, limits.get(EntityType.ITEM_FRAME));
+        assertEquals(5, limits.get(EntityType.GLOW_ITEM_FRAME));
+        assertEquals(3, limits.get(EntityType.PAINTING));
+    }
+
+    @Test
     void testInvalidGroupIconFallsBackToBarrier() {
         // Clear existing groups and add one with invalid icon
         config.set("entitygrouplimits", null);

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -44,6 +44,7 @@ import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.entity.Hanging;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Villager;
@@ -531,6 +532,72 @@ class EntityLimitListenerTest {
         ell.onBlock(event);
 
         assertFalse(event.isCancelled());
+    }
+
+    // --- Item frame limiting (#66) ---
+
+    @Test
+    void testItemFramePlaceAtLimitCancels() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ITEM_FRAME, 1);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.ITEM_FRAME);
+        ItemFrame frame = mockItemFrame();
+
+        Player player = mock(Player.class);
+        when(player.isOp()).thenReturn(false);
+        when(player.hasPermission(anyString())).thenReturn(false);
+
+        Block block = mock(Block.class);
+        when(block.getWorld()).thenReturn(world);
+        HangingPlaceEvent event = new HangingPlaceEvent(frame, player, block, BlockFace.SOUTH, EquipmentSlot.HAND, null);
+
+        ell.onBlock(event);
+
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    void testItemFramePlaceUnderLimitAllowedAndTracked() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.ITEM_FRAME, 2);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.ITEM_FRAME);
+        ItemFrame frame = mockItemFrame();
+
+        Player player = mock(Player.class);
+        when(player.isOp()).thenReturn(false);
+        when(player.hasPermission(anyString())).thenReturn(false);
+
+        Block block = mock(Block.class);
+        when(block.getWorld()).thenReturn(world);
+        HangingPlaceEvent event = new HangingPlaceEvent(frame, player, block, BlockFace.SOUTH, EquipmentSlot.HAND, null);
+
+        ell.onBlock(event);
+        assertFalse(event.isCancelled());
+
+        // MONITOR-priority tracker counts the placed frame
+        ell.onHangingPlaceTrack(event);
+        assertEquals(2, ibc.getEntityCount(Environment.NORMAL, EntityType.ITEM_FRAME));
+    }
+
+    @Test
+    void testItemFrameRemoveDecrements() throws Exception {
+        ItemFrame frame = mockItemFrame();
+        entityIslandMap().put(frame.getUniqueId(), "test-island-id");
+        ibc.incrementEntity(Environment.NORMAL, EntityType.ITEM_FRAME);
+        int before = ibc.getEntityCount(Environment.NORMAL, EntityType.ITEM_FRAME);
+
+        // Frame popped off the wall (dropped as an item) — must decrement like any removal
+        ell.onEntityRemove(new EntityRemoveEvent(frame, EntityRemoveEvent.Cause.DROP));
+
+        assertEquals(before - 1, ibc.getEntityCount(Environment.NORMAL, EntityType.ITEM_FRAME));
+        assertFalse(entityIslandMap().containsKey(frame.getUniqueId()));
+    }
+
+    private ItemFrame mockItemFrame() {
+        ItemFrame frame = mock(ItemFrame.class);
+        when(frame.getType()).thenReturn(EntityType.ITEM_FRAME);
+        when(frame.getLocation()).thenReturn(location);
+        when(frame.getWorld()).thenReturn(world);
+        when(frame.getUniqueId()).thenReturn(UUID.randomUUID());
+        return frame;
     }
 
     // --- Entity group limit tests ---


### PR DESCRIPTION
Fixes #66 (and the duplicate #143).

## Why now

Item frames and paintings were on the unsupported-entity list because the old scan-based counting couldn't track their many removal paths. That constraint is gone: entity counting is persistent and event-driven — `HangingPlaceEvent` already runs the limit check and increments the count, and `EntityRemoveEvent` decrements on every removal cause except chunk unload, which uniformly covers breaking, popping off due to obstruction, explosions, and plugin removal.

## Changes

- `Settings`: remove `ITEM_FRAME` and `PAINTING` from the `DISALLOWED` list so they can be configured under `entitylimits` (`GLOW_ITEM_FRAME` was never on the list — it parsed but was inconsistently handled downstream).
- `RecountCalculator`: count all `Hanging` entities in the entity scan instead of name-matching only `ITEM_FRAME`/`PAINTING`, which missed `GLOW_ITEM_FRAME`. This also matches what live tracking counts.
- `README`: move the three types out of the cannot-be-limited list.
- Tests: `entitylimits` parsing for the three types; item frame place-at-limit cancels, under-limit place increments via the MONITOR tracker, and removal via `DROP` decrements.

No GUI change needed: `LimitTab` already has icons for `ITEM_FRAME`/`PAINTING` and falls back to `Material.valueOf` for `GLOW_ITEM_FRAME`, which resolves.

## In-game test plan

1. Set `entitylimits: ITEM_FRAME: 3` (and optionally `GLOW_ITEM_FRAME: 2`, `PAINTING: 2`), restart.
2. Place 3 item frames on your island → 4th is blocked with the hit-limit message; `/is limits` shows 3/3.
3. Break one frame with a punch (drops as item) → count 2/3, a new frame can be placed.
4. Place a frame, then break the block behind it so it pops off → count decrements.
5. Put a map in a frame and break it → count decrements (frame with content).
6. TNT explosion removing frames → count decrements accordingly.
7. `/is limits recount` (or admin `limits calc`) → counts match what's physically present, including glow frames.
8. Nether/end: repeat step 2 in the nether — limits apply per environment independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB