### PR TITLE
Add option to count stackable plants as a single plant

### DIFF
--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -50,6 +50,7 @@ public class Settings {
     private final boolean logLimitsOnJoin;
     private final boolean asyncGolums;
     private final boolean showLimitMessages;
+    private final boolean stackedPlantsCountAsOne;
     private static final List<EntityType> DISALLOWED = Arrays.asList(
             EntityType.TNT,
             EntityType.EVOKER_FANGS,
@@ -96,6 +97,8 @@ public class Settings {
         asyncGolums = addon.getConfig().getBoolean("async-golums", true);
         // Show or suppress the "hit the limit" player notifications
         showLimitMessages = addon.getConfig().getBoolean("show-limit-messages", true);
+        // Count a stackable plant column (sugar cane, bamboo) as a single plant
+        stackedPlantsCountAsOne = addon.getConfig().getBoolean("stacked-plants-count-as-one", false);
 
         addon.log("Entity limits:");
         envLimits.forEach((env, m) -> m.entrySet().stream()
@@ -264,6 +267,14 @@ public class Settings {
      */
     public boolean isShowLimitMessages() {
         return showLimitMessages;
+    }
+
+    /**
+     * @return true if a column of stackable plants (sugar cane, bamboo) counts as one
+     *         plant; false if every segment counts (default)
+     */
+    public boolean isStackedPlantsCountAsOne() {
+        return stackedPlantsCountAsOne;
     }
 
     public Map<GeneralGroup, Integer> getGeneral() {

--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -161,13 +161,20 @@ public class RecountCalculator {
     }
 
     private void scanColumn(Environment env, ChunkSnapshot chunkSnapshot, int x, int z, int minY, int maxY) {
+        boolean stackedAsOne = addon.getSettings().isStackedPlantsCountAsOne();
+        NamespacedKey below = null;
         for (int y = minY; y < maxY; y++) {
             BlockData blockData = chunkSnapshot.getBlockData(x, y, z);
             if (Tag.SLABS.isTagged(blockData.getMaterial())
                     && ((Slab) blockData).getType().equals(Slab.Type.DOUBLE)) {
                 checkBlock(env, blockData);
             }
-            checkBlock(env, blockData);
+            NamespacedKey key = bll.fixMaterial(blockData);
+            // Stacked-plants-as-one: segments sitting on the same plant are not counted
+            if (!(stackedAsOne && BlockLimitsListener.STACKABLE.contains(key) && key.equals(below))) {
+                checkBlock(env, blockData);
+            }
+            below = key;
         }
     }
 

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -65,7 +65,8 @@ public class BlockLimitsListener implements Listener {
     private static final List<NamespacedKey> DO_NOT_COUNT = List.of(Material.LAVA.getKey(), Material.WATER.getKey(),
             Material.AIR.getKey(), Material.FIRE.getKey(), Material.END_PORTAL.getKey(),
             Material.NETHER_PORTAL.getKey());
-    private static final List<NamespacedKey> STACKABLE = List.of(Material.SUGAR_CANE.getKey(), Material.BAMBOO.getKey());
+    /** Plants that grow as a vertical column on top of themselves. */
+    public static final List<NamespacedKey> STACKABLE = List.of(Material.SUGAR_CANE.getKey(), Material.BAMBOO.getKey());
 
     /*
      * Materials added in Minecraft 1.21.9 ("Copper Age"). Resolved by name so the
@@ -269,7 +270,9 @@ public class BlockLimitsListener implements Listener {
             return;
         }
         Material mat = b.getType();
-        if (STACKABLE.contains(b.getType().getKey())) {
+        // When stacked plants count as one, only the base segment was ever counted,
+        // so the stems above must not be decremented here.
+        if (!addon.getSettings().isStackedPlantsCountAsOne() && STACKABLE.contains(b.getType().getKey())) {
             Block block = b;
             while (block.getRelative(BlockFace.UP).getType().equals(mat)
                     && block.getY() < b.getWorld().getMaxHeight()) {
@@ -407,6 +410,11 @@ public class BlockLimitsListener implements Listener {
         }
     }
 
+    /** True if the given material normalises to the same stackable plant key. */
+    private static boolean isSamePlant(Material below, NamespacedKey plantKey) {
+        return VARIANT_MAP.getOrDefault(below, below).getKey().equals(plantKey);
+    }
+
     /**
      * Map variant materials to their canonical form.
      */
@@ -430,6 +438,12 @@ public class BlockLimitsListener implements Listener {
      */
     private int process(Block b, BlockData blockData, boolean add) {
         if (DO_NOT_COUNT.contains(fixMaterial(blockData)) || !addon.inGameModeWorld(b.getWorld())) {
+            return -1;
+        }
+        // Stacked-plants-as-one: a segment sitting on the same plant is not counted,
+        // limited, or decremented — only the base segment represents the plant.
+        if (addon.getSettings().isStackedPlantsCountAsOne() && STACKABLE.contains(fixMaterial(blockData))
+                && isSamePlant(b.getRelative(BlockFace.DOWN).getType(), fixMaterial(blockData))) {
             return -1;
         }
         Environment env = envOf(b.getWorld());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,6 +46,12 @@ show-limit-messages: true
 blocklimits:
   HOPPER: 10
 
+# Count stackable plants (SUGAR_CANE, BAMBOO) as a single plant no matter how tall
+# they grow. When false (default), every segment of the plant counts toward the limit.
+# Run a recount (/<gamemode> limits recount) after changing this so stored counts
+# match the new counting rule.
+stacked-plants-count-as-one: false
+
 # Override block limits in the nether for this game mode.
 # Uncomment and add entries to set nether-only limits.
 #blocklimits-nether:

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -116,6 +116,18 @@ class SettingsTest {
     }
 
     @Test
+    void testStackedPlantsCountAsOneDefaultsFalse() {
+        assertFalse(settings.isStackedPlantsCountAsOne());
+    }
+
+    @Test
+    void testStackedPlantsCountAsOneEnabled() {
+        config.set("stacked-plants-count-as-one", true);
+        Settings s = new Settings(addon);
+        assertTrue(s.isStackedPlantsCountAsOne());
+    }
+
+    @Test
     void testGetGeneralEmpty() {
         // Default config.yml does not have ANIMALS or MOBS entries in entitylimits
         Map<Settings.GeneralGroup, Integer> general = settings.getGeneral();

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -138,6 +138,7 @@ class BlockLimitsListenerTest {
         doAnswer(invocation -> null).when(addon).log(anyString());
         doAnswer(invocation -> null).when(addon).logError(anyString());
         when(addon.isCoveredGameMode(anyString())).thenReturn(true);
+        // Limits settings: stacked-plants defaults false (mock default), messages on
         when(addon.getSettings()).thenReturn(limitsSettings);
         when(limitsSettings.isShowLimitMessages()).thenReturn(true);
         when(addon.inGameModeWorld(any(World.class))).thenReturn(false);
@@ -964,6 +965,61 @@ class BlockLimitsListenerTest {
         assertEquals(0, ibc.getBlockCount(Material.FARMLAND.getKey()));
         assertEquals(0, ibc.getBlockCount(Material.OAK_PLANKS.getKey()));
         assertEquals(1, ibc.getBlockCount(Material.DIRT.getKey()));
+    }
+
+    // --- Stacked plants count as one (#53) ---
+
+    @Test
+    void testStackedPlantSegmentNotCountedWhenEnabled() {
+        when(limitsSettings.isStackedPlantsCountAsOne()).thenReturn(true);
+        Block below = mockBlock(Material.SUGAR_CANE, new Location(world, 100, 64, 100));
+        Block block = mockBlock(Material.SUGAR_CANE, blockLocation);
+        when(block.getRelative(BlockFace.DOWN)).thenReturn(below);
+
+        BlockState replacedState = mock(BlockState.class);
+        BlockPlaceEvent event = new BlockPlaceEvent(block, replacedState, block,
+                new ItemStack(Material.SUGAR_CANE), player, true, EquipmentSlot.HAND);
+        listener.onBlock(event);
+
+        assertFalse(event.isCancelled());
+        IslandBlockCount ibc = listener.getIsland("test-island-id");
+        assertTrue(ibc == null || ibc.getBlockCount(Material.SUGAR_CANE.getKey()) == 0);
+    }
+
+    @Test
+    void testStackedPlantBaseCountedWhenEnabled() {
+        when(limitsSettings.isStackedPlantsCountAsOne()).thenReturn(true);
+        Block block = mockBlock(Material.SUGAR_CANE, blockLocation);
+        // Below is AIR from the mockBlock helper — this is the base segment
+
+        BlockState replacedState = mock(BlockState.class);
+        BlockPlaceEvent event = new BlockPlaceEvent(block, replacedState, block,
+                new ItemStack(Material.SUGAR_CANE), player, true, EquipmentSlot.HAND);
+        listener.onBlock(event);
+
+        assertEquals(1, listener.getIsland("test-island-id").getBlockCount(Material.SUGAR_CANE.getKey()));
+    }
+
+    @Test
+    void testStackedPlantBreakBaseDecrementsOnlyOneWhenEnabled() {
+        when(limitsSettings.isStackedPlantsCountAsOne()).thenReturn(true);
+        // Only the base was ever counted
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.add(Environment.NORMAL, Material.SUGAR_CANE.getKey());
+        listener.setIsland("test-island-id", ibc);
+
+        when(world.getMaxHeight()).thenReturn(320);
+        Block bottomBlock = mockBlock(Material.SUGAR_CANE, new Location(world, 100, 65, 100));
+        when(bottomBlock.getY()).thenReturn(65);
+        Block midBlock = mockBlock(Material.SUGAR_CANE, new Location(world, 100, 66, 100));
+        when(midBlock.getY()).thenReturn(66);
+        when(bottomBlock.getRelative(BlockFace.UP)).thenReturn(midBlock);
+
+        BlockBreakEvent event = new BlockBreakEvent(bottomBlock, player);
+        listener.onBlock(event);
+
+        // Exactly the one counted base is removed; the stem walk must not run
+        assertEquals(0, listener.getIsland("test-island-id").getBlockCount(Material.SUGAR_CANE.getKey()));
     }
 
     // --- Block cascade tests ---


### PR DESCRIPTION
Fixes #53.

Adds the config option Poslovitch suggested on the ticket:

```yaml
# Count stackable plants (SUGAR_CANE, BAMBOO) as a single plant no matter how tall
# they grow. When false (default), every segment of the plant counts toward the limit.
stacked-plants-count-as-one: false
```

## How it works

One rule, applied in three places: **a stackable segment sitting on the same plant is invisible to counting** — only the base segment represents the plant.

- `process()` (all place/grow/spread paths funnel through it): segments above the same plant are skipped for counting, limit checks, and decrements.
- `handleBreak()`: the existing stem-cascade decrement is disabled when the option is on, since stems were never counted. Breaking a middle stem leaves the plant counted (the base still stands); breaking the base decrements the one counted plant.
- `RecountCalculator`: the column scan skips a stackable whose block below normalised to the same plant, so recounts agree with live counts.

`BAMBOO_SAPLING` normalises to `BAMBOO` (existing variant map), so a stem above a sapling reads as the same plant. Default off preserves today's per-segment behaviour exactly — the config comment tells admins to run a recount after flipping the option.

## Tests

Segment-not-counted, base-counted, and break-decrements-exactly-one cases, plus config parsing; the pre-existing cascade test pins the default-off behaviour. Full suite green.

## In-game test plan

1. Enable the option, set `SUGAR_CANE: 5`, restart.
2. Plant 5 canes → 6th blocked. Let them grow to full height → `/is limits` still 5/5.
3. Break a middle segment of one cane → still 5/5 (plant remains). Break a base → 4/5.
4. `/is limits recount` at any point → number unchanged.
5. Repeat 2–4 with bamboo (including placing bamboo items on existing stalks — should not change the count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB