### PR TITLE
Add optional manual material/entity name translations in locale files

### DIFF
--- a/src/main/java/world/bentobox/limits/DisplayNames.java
+++ b/src/main/java/world/bentobox/limits/DisplayNames.java
@@ -1,0 +1,44 @@
+package world.bentobox.limits;
+
+import java.util.Locale;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.EntityType;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Resolves the display name of a limited material or entity for a user.
+ *
+ * <p>Locale files may provide manual translations under
+ * {@code island.limits.materials.<material>} and {@code island.limits.entities.<entity>}
+ * (lowercase Bukkit names). Any key without a translation falls back to the automatic
+ * prettified English name, so translations are entirely optional.
+ */
+public final class DisplayNames {
+
+    private DisplayNames() {
+    }
+
+    /**
+     * @param user the user whose locale is used
+     * @param key the material key, e.g. {@code minecraft:hopper}
+     * @return translated material name, or the prettified key if no translation exists
+     */
+    public static String material(User user, NamespacedKey key) {
+        String translated = user.getTranslationOrNothing("island.limits.materials." + key.getKey());
+        return translated == null || translated.isEmpty() ? Util.prettifyText(key.getKey()) : translated;
+    }
+
+    /**
+     * @param user the user whose locale is used
+     * @param type the entity type
+     * @return translated entity name, or the prettified type name if no translation exists
+     */
+    public static String entity(User user, EntityType type) {
+        String translated = user
+                .getTranslationOrNothing("island.limits.entities." + type.toString().toLowerCase(Locale.ROOT));
+        return translated == null || translated.isEmpty() ? Util.prettifyText(type.toString()) : translated;
+    }
+}

--- a/src/main/java/world/bentobox/limits/commands/player/LimitTab.java
+++ b/src/main/java/world/bentobox/limits/commands/player/LimitTab.java
@@ -26,6 +26,7 @@ import world.bentobox.bentobox.api.panels.Tab;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
+import world.bentobox.limits.DisplayNames;
 import world.bentobox.limits.EntityGroup;
 import world.bentobox.limits.Limits;
 import world.bentobox.limits.objects.IslandBlockCount;
@@ -112,7 +113,7 @@ public class LimitTab implements Tab {
             PanelItemBuilder pib = new PanelItemBuilder();
             pib.name(user.getTranslation("island.limits.panel.entity-group-name-syntax", TextVariables.NAME,
                     g.getName()));
-            String description = "(" + prettyNames(g) + ")\n";
+            String description = "(" + prettyNames(user, g) + ")\n";
             pib.icon(g.getIcon());
             int count = ibc == null ? 0 : sumGroupCount(ibc, g);
             String color = count >= limit ? user.getTranslation(MAX_COLOR_KEY)
@@ -144,7 +145,7 @@ public class LimitTab implements Tab {
         map.forEach((k, v) -> {
             PanelItemBuilder pib = new PanelItemBuilder();
             pib.name(user.getTranslation("island.limits.panel.entity-name-syntax", TextVariables.NAME,
-                    Util.prettifyText(k.toString())));
+                    DisplayNames.entity(user, k)));
             Material m;
             try {
                 if (E2M.containsKey(k)) {
@@ -172,7 +173,7 @@ public class LimitTab implements Tab {
         for (Entry<NamespacedKey, Integer> en : matLimits.entrySet()) {
             PanelItemBuilder pib = new PanelItemBuilder();
             pib.name(user.getTranslation("island.limits.panel.block-name-syntax", TextVariables.NAME,
-                    Util.prettifyText(en.getKey().getKey())));
+                    DisplayNames.material(user, en.getKey())));
             Material mat = Registry.MATERIAL.get(B2M.getOrDefault(en.getKey(), en.getKey()));
             pib.icon(Objects.requireNonNullElse(mat, Material.PAPER));
 
@@ -222,11 +223,11 @@ public class LimitTab implements Tab {
         return "";
     }
 
-    private String prettyNames(EntityGroup v) {
+    private String prettyNames(User user, EntityGroup v) {
         StringBuilder sb = new StringBuilder();
         List<EntityType> l = new ArrayList<>(v.getTypes());
         for (int i = 0; i < l.size(); i++) {
-            sb.append(Util.prettifyText(l.get(i).toString()));
+            sb.append(DisplayNames.entity(user, l.get(i)));
             if (i + 1 < l.size()) sb.append(", ");
             if ((i + 1) % 5 == 0) sb.append("\n");
         }

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -52,6 +52,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.Database;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
+import world.bentobox.limits.DisplayNames;
 import world.bentobox.limits.Limits;
 import world.bentobox.limits.Settings;
 import world.bentobox.limits.objects.IslandBlockCount;
@@ -307,7 +308,7 @@ public class BlockLimitsListener implements Listener {
         if (limit > -1) {
             if (addon.getSettings().isShowLimitMessages()) {
                 user.notify("block-limits.hit-limit",
-                        "[material]", Util.prettifyText(m.toString()),
+                        "[material]", DisplayNames.material(user, m.getKey()),
                         TextVariables.NUMBER, String.valueOf(limit));
             }
             e.setCancelled(true);

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -28,6 +28,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.limits.EntityGroup;
+import world.bentobox.limits.DisplayNames;
 import world.bentobox.limits.Limits;
 import world.bentobox.limits.Settings;
 import world.bentobox.limits.objects.IslandBlockCount;
@@ -151,15 +152,16 @@ public class EntityLimitListener implements Listener {
                 if (!addon.getSettings().isShowLimitMessages()) {
                     return;
                 }
+                User u = User.getInstance(player);
                 if (res.getTypelimit() != null) {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
-                            Util.prettifyText(hangingPlaceEvent.getEntity().getType().toString()),
+                    u.notify("block-limits.hit-limit", "[material]",
+                            DisplayNames.entity(u, hangingPlaceEvent.getEntity().getType()),
                             TextVariables.NUMBER, String.valueOf(res.getTypelimit().getValue()));
                 } else {
-                    User.getInstance(player).notify("block-limits.hit-limit", "[material]",
+                    u.notify("block-limits.hit-limit", "[material]",
                             res.getGrouplimit().getKey().getName() + " ("
                                     + res.getGrouplimit().getKey().getTypes().stream()
-                                            .map(x -> Util.prettifyText(x.toString()))
+                                            .map(x -> DisplayNames.entity(u, x))
                                             .collect(Collectors.joining(", "))
                                     + ")",
                             TextVariables.NUMBER, String.valueOf(res.getGrouplimit().getValue()));
@@ -235,15 +237,16 @@ public class EntityLimitListener implements Listener {
         if (!addon.getSettings().isShowLimitMessages()) {
             return;
         }
+        User u = User.getInstance(player);
         if (res.getTypelimit() != null) {
-            User.getInstance(player).notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
-                    Util.prettifyText(type.toString()), TextVariables.NUMBER,
+            u.notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
+                    DisplayNames.entity(u, type), TextVariables.NUMBER,
                     String.valueOf(res.getTypelimit().getValue()));
         } else {
-            User.getInstance(player).notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
+            u.notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
                     res.getGrouplimit().getKey().getName() + " ("
                             + res.getGrouplimit().getKey().getTypes().stream()
-                                    .map(x -> Util.prettifyText(x.toString()))
+                                    .map(x -> DisplayNames.entity(u, x))
                                     .collect(Collectors.joining(", "))
                             + ")",
                     TextVariables.NUMBER, String.valueOf(res.getGrouplimit().getValue()));
@@ -568,15 +571,16 @@ public class EntityLimitListener implements Listener {
             for (Entity ent : w.getNearbyEntities(location, 5, 5, 5)) {
                 if (ent instanceof Player p) {
                     p.updateInventory();
+                    User u = User.getInstance(p);
                     if (res.getTypelimit() != null) {
-                        User.getInstance(p).notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
-                                Util.prettifyText(entity.getType().toString()),
+                        u.notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
+                                DisplayNames.entity(u, entity.getType()),
                                 TextVariables.NUMBER, String.valueOf(res.getTypelimit().getValue()));
                     } else {
-                        User.getInstance(p).notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
+                        u.notify(ENTITY_LIMIT_HIT, ENTITY_PLACEHOLDER,
                                 res.getGrouplimit().getKey().getName() + " ("
                                         + res.getGrouplimit().getKey().getTypes().stream()
-                                                .map(x -> Util.prettifyText(x.toString()))
+                                                .map(x -> DisplayNames.entity(u, x))
                                                 .collect(Collectors.joining(", "))
                                         + ")",
                                 TextVariables.NUMBER, String.valueOf(res.getGrouplimit().getValue()));

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -46,6 +46,13 @@ admin:
 island:
   limits:
     description: "show your island limits"
+    # Optional manual name translations, used in the limits GUI and hit-limit messages.
+    # Keys are lowercase Bukkit Material / EntityType names. Anything not listed falls
+    # back to the automatic English name, so these sections can be left empty.
+    #materials:
+    #  hopper: "Hopper"
+    #entities:
+    #  enderman: "Enderman"
     max-color: "<red>"
     regular-color: "<green>"
     block-limit-syntax: "[number]/[limit]"

--- a/src/test/java/world/bentobox/limits/DisplayNamesTest.java
+++ b/src/test/java/world/bentobox/limits/DisplayNamesTest.java
@@ -1,0 +1,50 @@
+package world.bentobox.limits;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import world.bentobox.bentobox.api.user.User;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DisplayNamesTest {
+
+    @Mock
+    private User user;
+
+    @Test
+    void testMaterialTranslated() {
+        when(user.getTranslationOrNothing(anyString())).thenReturn("");
+        when(user.getTranslationOrNothing("island.limits.materials.hopper")).thenReturn("Trichter");
+        assertEquals("Trichter", DisplayNames.material(user, Material.HOPPER.getKey()));
+    }
+
+    @Test
+    void testMaterialFallsBackToPrettyName() {
+        when(user.getTranslationOrNothing(anyString())).thenReturn("");
+        assertEquals("Hopper", DisplayNames.material(user, Material.HOPPER.getKey()));
+    }
+
+    @Test
+    void testEntityTranslated() {
+        when(user.getTranslationOrNothing(anyString())).thenReturn("");
+        when(user.getTranslationOrNothing("island.limits.entities.enderman")).thenReturn("Enderman (DE)");
+        assertEquals("Enderman (DE)", DisplayNames.entity(user, EntityType.ENDERMAN));
+    }
+
+    @Test
+    void testEntityFallsBackToPrettyName() {
+        when(user.getTranslationOrNothing(anyString())).thenReturn("");
+        assertEquals("Enderman", DisplayNames.entity(user, EntityType.ENDERMAN));
+    }
+}


### PR DESCRIPTION
Fixes #188.

Follows the Challenges pattern the reporter asked for: locale files can now translate the block/entity names shown in the limits GUI and in hit-limit chat messages.

```yaml
island:
  limits:
    materials:
      hopper: "漏斗"
    entities:
      enderman: "末影人"
```

- Keys are lowercase Bukkit `Material` / `EntityType` names; anything not listed falls back to the automatic prettified English name, so the sections are optional and existing locale files need no changes.
- A new `DisplayNames` helper centralises the lookup; it's applied in the limits panel (block rows, entity rows, group member lists) and in every hit-limit notification (block, hanging place, entity spawn, nearby-player broadcast).
- Commented showcase entries added to `en-US.yml`.

Tests cover translated and fallback paths for both materials and entities. Full suite green.

In-game check: add `materials: { hopper: "Trichter" }` to your locale, `/ob limits` → the hopper row shows "Trichter"; hit the hopper limit → the message uses "Trichter".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB