### PR TITLE
Add block group limits

### DIFF
--- a/src/main/java/world/bentobox/limits/BlockGroup.java
+++ b/src/main/java/world/bentobox/limits/BlockGroup.java
@@ -1,0 +1,59 @@
+package world.bentobox.limits;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+
+/**
+ * A named group of block materials sharing a single limit. The counts of every
+ * member material are summed and checked against the group limit.
+ */
+public class BlockGroup {
+    private final String name;
+    private final Set<NamespacedKey> keys;
+    private final int limit;
+    private final Material icon;
+
+    public BlockGroup(String name, Set<NamespacedKey> keys, int limit, Material icon) {
+        this.name = name;
+        this.keys = keys;
+        this.limit = limit;
+        this.icon = icon;
+    }
+
+    public boolean contains(NamespacedKey key) {
+        return keys.contains(key);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<NamespacedKey> getKeys() {
+        return keys;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public Material getIcon() {
+        return icon;
+    }
+
+    @Override
+    public int hashCode() {
+        return 83 * 7 + Objects.hashCode(this.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        return Objects.equals(this.name, ((BlockGroup) obj).name);
+    }
+}

--- a/src/main/java/world/bentobox/limits/Settings.java
+++ b/src/main/java/world/bentobox/limits/Settings.java
@@ -38,6 +38,8 @@ public class Settings {
 
     private static final String SKIPPING = " - skipping...";
     private static final String LIMIT_SUFFIX = ".limit";
+    private static final String LIMIT_LOG_PREFIX = "Limit ";
+    private static final String GROUP_OVERRIDE_PREFIX = "Group override ";
 
     private final Map<GeneralGroup, Integer> general = new EnumMap<>(GeneralGroup.class);
     /** Per-env entity type limits (env defaults from config). */
@@ -46,6 +48,10 @@ public class Settings {
     private final Map<EntityType, List<EntityGroup>> groupLimits = new EnumMap<>(EntityType.class);
     /** Per-env group-limit overrides (env defaults from config). */
     private final Map<Environment, Map<String, Integer>> envGroupLimits = new EnumMap<>(Environment.class);
+    /** Block group definitions and which groups each canonical block key belongs to. */
+    private final Map<org.bukkit.NamespacedKey, List<BlockGroup>> blockGroups = new java.util.HashMap<>();
+    /** Per-env block-group limits (defaults from config plus env overrides). */
+    private final Map<Environment, Map<String, Integer>> envBlockGroupLimits = new EnumMap<>(Environment.class);
     private final List<String> gameModes;
     private final boolean logLimitsOnJoin;
     private final boolean asyncGolums;
@@ -84,6 +90,7 @@ public class Settings {
         for (Environment env : ENVIRONMENTS) {
             envLimits.put(env, new EnumMap<>(EntityType.class));
             envGroupLimits.put(env, new java.util.HashMap<>());
+            envBlockGroupLimits.put(env, new java.util.HashMap<>());
         }
 
         // Pass 1: parse the unsuffixed entitylimits as the default for every env
@@ -105,7 +112,7 @@ public class Settings {
 
         addon.log("Entity limits:");
         envLimits.forEach((env, m) -> m.entrySet().stream()
-                .map(e -> "Limit " + e.getKey() + " in " + env + " to " + e.getValue())
+                .map(e -> LIMIT_LOG_PREFIX + e.getKey() + " in " + env + " to " + e.getValue())
                 .forEach(addon::log));
 
         // Group definitions live in the unsuffixed entitygrouplimits section. The entire
@@ -117,10 +124,78 @@ public class Settings {
 
         addon.log("Entity group limits:");
         getGroupLimitDefinitions().stream()
-                .map(e -> "Limit " + e.getName() + " ("
+                .map(e -> LIMIT_LOG_PREFIX + e.getName() + " ("
                         + e.getTypes().stream().map(Enum::name).collect(Collectors.joining(", ")) + ") to "
                         + e.getLimit())
                 .forEach(addon::log);
+
+        // Block groups follow the same pattern as entity groups.
+        loadBlockGroupDefinitions(addon);
+        loadBlockGroupLimitOverrides(addon, "blockgrouplimits-nether", Environment.NETHER);
+        loadBlockGroupLimitOverrides(addon, "blockgrouplimits-end", Environment.THE_END);
+
+        addon.log("Block group limits:");
+        getBlockGroupDefinitions().stream()
+                .map(g -> LIMIT_LOG_PREFIX + g.getName() + " ("
+                        + g.getKeys().stream().map(org.bukkit.NamespacedKey::getKey)
+                                .collect(Collectors.joining(", "))
+                        + ") to " + g.getLimit())
+                .forEach(addon::log);
+    }
+
+    private void loadBlockGroupDefinitions(Limits addon) {
+        ConfigurationSection el = addon.getConfig().getConfigurationSection("blockgrouplimits");
+        if (el == null) return;
+        for (String name : el.getKeys(false)) {
+            int limit = el.getInt(name + LIMIT_SUFFIX);
+            Material icon = parseIcon(addon, el.getString(name + ".icon", "BARRIER"));
+            Set<org.bukkit.NamespacedKey> keys = el.getStringList(name + ".materials").stream().map(m -> {
+                Material material = Material.matchMaterial(m);
+                if (material == null || !material.isBlock()) {
+                    addon.logError("Unknown block material in blockgrouplimits." + name + ": " + m + SKIPPING);
+                    return null;
+                }
+                return world.bentobox.limits.listeners.BlockLimitsListener.canonicalKey(material);
+            }).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
+            if (keys.isEmpty()) continue;
+            BlockGroup group = new BlockGroup(name, keys, limit, icon);
+            keys.forEach(k -> blockGroups.computeIfAbsent(k, x -> new ArrayList<>()).add(group));
+            // Default group limit applies to every env unless overridden.
+            ENVIRONMENTS.forEach(env -> envBlockGroupLimits.get(env).put(name, limit));
+        }
+    }
+
+    private void loadBlockGroupLimitOverrides(Limits addon, String section, Environment env) {
+        ConfigurationSection el = addon.getConfig().getConfigurationSection(section);
+        if (el == null) return;
+        for (String name : el.getKeys(false)) {
+            applyBlockGroupOverride(addon, el, section, name, env);
+        }
+    }
+
+    private void applyBlockGroupOverride(Limits addon, ConfigurationSection el, String section, String name,
+            Environment env) {
+        Integer limit = resolveGroupLimit(el, name);
+        if (limit == null) {
+            addon.logError(GROUP_OVERRIDE_PREFIX + section + "." + name + " missing limit - skipping.");
+            return;
+        }
+        // Group must already be defined in the base blockgrouplimits section
+        if (getBlockGroupDefinitions().stream().noneMatch(g -> g.getName().equals(name))) {
+            addon.logError(GROUP_OVERRIDE_PREFIX + section + "." + name
+                    + " refers to an undefined group - define it under blockgrouplimits first.");
+            return;
+        }
+        envBlockGroupLimits.get(env).put(name, limit);
+    }
+
+    private Material parseIcon(Limits addon, String iconName) {
+        try {
+            return Material.valueOf(iconName.toUpperCase(Locale.ENGLISH));
+        } catch (Exception e) {
+            addon.logError("Invalid group icon name: " + iconName + ". Use a Bukkit Material.");
+            return Material.BARRIER;
+        }
     }
 
     private void loadEntityLimits(Limits addon, String section, List<Environment> targetEnvs) {
@@ -161,14 +236,7 @@ public class Settings {
         if (el == null) return;
         for (String name : el.getKeys(false)) {
             int limit = el.getInt(name + LIMIT_SUFFIX);
-            String iconName = el.getString(name + ".icon", "BARRIER");
-            Material icon;
-            try {
-                icon = Material.valueOf(iconName.toUpperCase(Locale.ENGLISH));
-            } catch (Exception e) {
-                addon.logError("Invalid group icon name: " + iconName + ". Use a Bukkit Material.");
-                icon = Material.BARRIER;
-            }
+            Material icon = parseIcon(addon, el.getString(name + ".icon", "BARRIER"));
             Set<EntityType> entities = el.getStringList(name + ".entities").stream().map(s -> {
                 EntityType type = getType(s);
                 if (type == null) {
@@ -202,13 +270,13 @@ public class Settings {
         // Accept either a flat int (Monsters: 100) or a nested .limit (Monsters.limit: 100)
         Integer limit = resolveGroupLimit(el, name);
         if (limit == null) {
-            addon.logError("Group override " + section + "." + name + " missing limit - skipping.");
+            addon.logError(GROUP_OVERRIDE_PREFIX + section + "." + name + " missing limit - skipping.");
             return;
         }
         // Group must already be defined in the base entitygrouplimits section
         boolean exists = getGroupLimitDefinitions().stream().anyMatch(g -> g.getName().equals(name));
         if (!exists) {
-            addon.logError("Group override " + section + "." + name
+            addon.logError(GROUP_OVERRIDE_PREFIX + section + "." + name
                     + " refers to an undefined group - define it under entitygrouplimits first.");
             return;
         }
@@ -285,6 +353,35 @@ public class Settings {
      */
     public boolean isApplyMemberLimitPerms() {
         return applyMemberLimitPerms;
+    }
+
+    /**
+     * @param key canonical block key
+     * @return block groups containing this key; empty if none
+     */
+    public List<BlockGroup> getBlockGroups(org.bukkit.NamespacedKey key) {
+        return blockGroups.getOrDefault(key, Collections.emptyList());
+    }
+
+    /**
+     * @return true if the key belongs to any block group
+     */
+    public boolean isInBlockGroup(org.bukkit.NamespacedKey key) {
+        return blockGroups.containsKey(key);
+    }
+
+    /**
+     * @return all defined block groups
+     */
+    public List<BlockGroup> getBlockGroupDefinitions() {
+        return blockGroups.values().stream().flatMap(Collection::stream).distinct().toList();
+    }
+
+    /**
+     * @return the block group's limit in this environment, or -1 if not defined
+     */
+    public int getBlockGroupLimit(Environment env, String name) {
+        return envBlockGroupLimits.getOrDefault(env, Collections.emptyMap()).getOrDefault(name, -1);
     }
 
     public Map<GeneralGroup, Integer> getGeneral() {

--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -88,8 +88,10 @@ public class RecountCalculator {
 
     private void checkBlock(Environment env, BlockData b) {
         NamespacedKey md = bll.fixMaterial(b);
-        // Only count materials that are tracked at any level (env default, world override, island).
-        if (bll.getMaterialLimits(worlds.get(env), island.getUniqueId()).containsKey(md)) {
+        // Only count materials that are tracked at any level (env default, world override,
+        // island, or block group membership).
+        if (bll.getMaterialLimits(worlds.get(env), island.getUniqueId()).containsKey(md)
+                || addon.getSettings().isInBlockGroup(md)) {
             results.getBlockCount(env).add(md);
         }
     }

--- a/src/main/java/world/bentobox/limits/commands/player/LimitTab.java
+++ b/src/main/java/world/bentobox/limits/commands/player/LimitTab.java
@@ -87,6 +87,7 @@ public class LimitTab implements Tab {
         this.env = env;
         result = new ArrayList<>();
         addMaterialIcons(ibc, matLimits);
+        addBlockGroupIcons(ibc);
         addEntityLimits(ibc);
         addEntityGroupLimits(ibc);
         result.sort(Comparator.comparing(PanelItem::getName));
@@ -184,6 +185,30 @@ public class LimitTab implements Tab {
             pib.description(color + user.getTranslation(BLOCK_LIMIT_SYNTAX_KEY,
                     TextVariables.NUMBER, String.valueOf(count),
                     LIMIT_PLACEHOLDER, String.valueOf(value)));
+            result.add(pib.build());
+        }
+    }
+
+    private void addBlockGroupIcons(IslandBlockCount ibc) {
+        for (world.bentobox.limits.BlockGroup g : addon.getSettings().getBlockGroupDefinitions()) {
+            int limit = addon.getSettings().getBlockGroupLimit(env, g.getName());
+            if (limit < 0) {
+                continue;
+            }
+            PanelItemBuilder pib = new PanelItemBuilder();
+            pib.name(user.getTranslation("island.limits.panel.block-group-name-syntax", TextVariables.NAME,
+                    g.getName()));
+            String description = "(" + g.getKeys().stream().map(k -> Util.prettifyText(k.getKey()))
+                    .collect(Collectors.joining(", ")) + ")\n";
+            pib.icon(g.getIcon());
+            int count = ibc == null ? 0
+                    : g.getKeys().stream().mapToInt(k -> ibc.getBlockCount(env, k)).sum();
+            String color = count >= limit ? user.getTranslation(MAX_COLOR_KEY)
+                    : user.getTranslation(REGULAR_COLOR_KEY);
+            description += color + user.getTranslation(BLOCK_LIMIT_SYNTAX_KEY,
+                    TextVariables.NUMBER, String.valueOf(count),
+                    LIMIT_PLACEHOLDER, String.valueOf(limit));
+            pib.description(description);
             result.add(pib.build());
         }
     }

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -417,6 +417,13 @@ public class BlockLimitsListener implements Listener {
     }
 
     /**
+     * @return the canonical key for a material after variant normalisation
+     */
+    public static NamespacedKey canonicalKey(Material m) {
+        return VARIANT_MAP.getOrDefault(m, m).getKey();
+    }
+
+    /**
      * Map variant materials to their canonical form.
      */
     public NamespacedKey fixMaterial(BlockData b) {
@@ -503,6 +510,34 @@ public class BlockLimitsListener implements Listener {
      * @return limit if at or over, or -1 if no limit
      */
     private int checkLimit(World w, Environment env, NamespacedKey m, String id) {
+        int single = checkSingleLimit(w, env, m, id);
+        if (single > -1) {
+            return single;
+        }
+        return checkBlockGroupLimit(env, m, islandCountMap.get(id));
+    }
+
+    /**
+     * Check the block groups this material belongs to: the counts of all group members
+     * are summed and compared against the group's limit for this environment.
+     *
+     * @return group limit if at or over, or -1 if no group limit is hit
+     */
+    private int checkBlockGroupLimit(Environment env, NamespacedKey m, IslandBlockCount ibc) {
+        for (world.bentobox.limits.BlockGroup group : addon.getSettings().getBlockGroups(m)) {
+            int limit = addon.getSettings().getBlockGroupLimit(env, group.getName());
+            if (limit < 0) {
+                continue;
+            }
+            int sum = group.getKeys().stream().mapToInt(k -> ibc.getBlockCount(env, k)).sum();
+            if (sum >= limit) {
+                return limit;
+            }
+        }
+        return -1;
+    }
+
+    private int checkSingleLimit(World w, Environment env, NamespacedKey m, String id) {
         IslandBlockCount ibc = islandCountMap.get(id);
         if (ibc.isBlockLimited(env, m)) {
             int offset = ibc.getBlockLimitOffset(env, m);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -71,6 +71,36 @@ stacked-plants-count-as-one: false
 #blocklimits-end:
 #  HOPPER: 5
 
+# Block Groups
+# Same idea as entity groups below: one shared limit across a set of block materials.
+# The counts of every member are summed and checked against the group limit, so players
+# cannot dodge a limit by converting between related blocks (e.g. grass -> dirt) or
+# splitting across variants (e.g. pistons and sticky pistons).
+# Individual blocklimits still apply on top if both are set.
+# Run a recount (/<gamemode> limits recount) after adding a group so existing blocks
+# are counted.
+#blockgrouplimits:
+#  Pistons:
+#    icon: PISTON
+#    limit: 10
+#    materials:
+#    - PISTON
+#    - STICKY_PISTON
+#  Soil:
+#    icon: GRASS_BLOCK
+#    limit: 200
+#    materials:
+#    - GRASS_BLOCK
+#    - DIRT
+#    - DIRT_PATH
+#    - FARMLAND
+# Override a block group's limit per environment. The group must already be defined
+# in blockgrouplimits; only the numeric limit can be overridden.
+#blockgrouplimits-nether:
+#  Pistons: 5
+#blockgrouplimits-end:
+#  Pistons: 5
+
 # This section is for world-named limits and overrides any environment-default limit
 # above for that specific world. Specify each world you want to limit individually
 # (including nether and end worlds). If these worlds are not covered by the game modes

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -62,6 +62,7 @@ island:
         entity-group-name-syntax: '[name]'
         entity-name-syntax: '[name]'
         block-name-syntax: '[name]'
+        block-group-name-syntax: '[name]'
         env-overworld: "Overworld"
         env-nether: "Nether"
         env-end: "End"

--- a/src/test/java/world/bentobox/limits/SettingsTest.java
+++ b/src/test/java/world/bentobox/limits/SettingsTest.java
@@ -163,6 +163,47 @@ class SettingsTest {
         assertFalse(s.getLimits(Environment.NORMAL).containsKey(EntityType.TNT));
     }
 
+    // --- Block group limits (#12) ---
+
+    @Test
+    void testBlockGroupLimitsParsed() {
+        config.set("blockgrouplimits.Pistons.icon", "PISTON");
+        config.set("blockgrouplimits.Pistons.limit", 10);
+        config.set("blockgrouplimits.Pistons.materials", List.of("PISTON", "STICKY_PISTON"));
+        config.set("blockgrouplimits-nether.Pistons", 5);
+        Settings s = new Settings(addon);
+
+        assertEquals(1, s.getBlockGroupDefinitions().size());
+        BlockGroup group = s.getBlockGroupDefinitions().get(0);
+        assertEquals("Pistons", group.getName());
+        assertEquals(Material.PISTON, group.getIcon());
+        assertTrue(s.isInBlockGroup(Material.PISTON.getKey()));
+        assertTrue(s.isInBlockGroup(Material.STICKY_PISTON.getKey()));
+        assertFalse(s.isInBlockGroup(Material.DIRT.getKey()));
+        assertEquals(10, s.getBlockGroupLimit(Environment.NORMAL, "Pistons"));
+        assertEquals(5, s.getBlockGroupLimit(Environment.NETHER, "Pistons"));
+        assertEquals(10, s.getBlockGroupLimit(Environment.THE_END, "Pistons"));
+        assertEquals(-1, s.getBlockGroupLimit(Environment.NORMAL, "Nope"));
+    }
+
+    @Test
+    void testBlockGroupUnknownMaterialSkipped() {
+        config.set("blockgrouplimits.Bad.limit", 10);
+        config.set("blockgrouplimits.Bad.materials", List.of("NOT_A_BLOCK_XYZ"));
+        Settings s = new Settings(addon);
+        verify(addon).logError("Unknown block material in blockgrouplimits.Bad: NOT_A_BLOCK_XYZ - skipping...");
+        // All members invalid -> group not created
+        assertTrue(s.getBlockGroupDefinitions().isEmpty());
+    }
+
+    @Test
+    void testBlockGroupOverrideForUndefinedGroupLogsError() {
+        config.set("blockgrouplimits-end.Ghost", 5);
+        new Settings(addon);
+        verify(addon).logError("Group override blockgrouplimits-end.Ghost"
+                + " refers to an undefined group - define it under blockgrouplimits first.");
+    }
+
     @Test
     void testHangingEntityLimitsParsed() {
         config.set("entitylimits.ITEM_FRAME", 10);

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -138,7 +138,7 @@ class BlockLimitsListenerTest {
         doAnswer(invocation -> null).when(addon).log(anyString());
         doAnswer(invocation -> null).when(addon).logError(anyString());
         when(addon.isCoveredGameMode(anyString())).thenReturn(true);
-        // Limits settings: stacked-plants defaults false (mock default), messages on
+        // Limits settings mock: stacked-plants and block groups default off, messages on
         when(addon.getSettings()).thenReturn(limitsSettings);
         when(limitsSettings.isShowLimitMessages()).thenReturn(true);
         when(addon.inGameModeWorld(any(World.class))).thenReturn(false);
@@ -1020,6 +1020,81 @@ class BlockLimitsListenerTest {
 
         // Exactly the one counted base is removed; the stem walk must not run
         assertEquals(0, listener.getIsland("test-island-id").getBlockCount(Material.SUGAR_CANE.getKey()));
+    }
+
+    // --- Block group limits (#12) ---
+
+    private void setUpPistonGroup(int limit) {
+        world.bentobox.limits.BlockGroup group = new world.bentobox.limits.BlockGroup("Pistons",
+                java.util.Set.of(Material.PISTON.getKey(), Material.STICKY_PISTON.getKey()), limit, Material.PISTON);
+        when(limitsSettings.getBlockGroups(Material.PISTON.getKey())).thenReturn(List.of(group));
+        when(limitsSettings.getBlockGroups(Material.STICKY_PISTON.getKey())).thenReturn(List.of(group));
+        when(limitsSettings.getBlockGroupLimit(Environment.NORMAL, "Pistons")).thenReturn(limit);
+    }
+
+    @Test
+    void testBlockGroupLimitCancelsWhenGroupFull() {
+        setUpPistonGroup(10);
+        // 6 pistons + 4 sticky pistons = 10, group full
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        for (int i = 0; i < 6; i++) {
+            ibc.add(Environment.NORMAL, Material.PISTON.getKey());
+        }
+        for (int i = 0; i < 4; i++) {
+            ibc.add(Environment.NORMAL, Material.STICKY_PISTON.getKey());
+        }
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.PISTON, blockLocation);
+        BlockState replacedState = mock(BlockState.class);
+        BlockPlaceEvent event = new BlockPlaceEvent(block, replacedState, block,
+                new ItemStack(Material.PISTON), player, true, EquipmentSlot.HAND);
+        listener.onBlock(event);
+
+        assertTrue(event.isCancelled());
+        // Nothing was added on the cancel path
+        assertEquals(6, listener.getIsland("test-island-id").getBlockCount(Material.PISTON.getKey()));
+    }
+
+    @Test
+    void testBlockGroupLimitAllowsWhenUnderAndCounts() {
+        setUpPistonGroup(10);
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        for (int i = 0; i < 5; i++) {
+            ibc.add(Environment.NORMAL, Material.PISTON.getKey());
+        }
+        for (int i = 0; i < 4; i++) {
+            ibc.add(Environment.NORMAL, Material.STICKY_PISTON.getKey());
+        }
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.STICKY_PISTON, blockLocation);
+        BlockState replacedState = mock(BlockState.class);
+        BlockPlaceEvent event = new BlockPlaceEvent(block, replacedState, block,
+                new ItemStack(Material.STICKY_PISTON), player, true, EquipmentSlot.HAND);
+        listener.onBlock(event);
+
+        assertFalse(event.isCancelled());
+        assertEquals(5, listener.getIsland("test-island-id").getBlockCount(Material.STICKY_PISTON.getKey()));
+    }
+
+    @Test
+    void testIndividualLimitStillAppliesInsideGroup() {
+        setUpPistonGroup(10);
+        // Island-specific individual limit of 2 on PISTON is tighter than the group
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.setBlockLimit(Environment.NORMAL, Material.PISTON.getKey(), 2);
+        ibc.add(Environment.NORMAL, Material.PISTON.getKey());
+        ibc.add(Environment.NORMAL, Material.PISTON.getKey());
+        listener.setIsland("test-island-id", ibc);
+
+        Block block = mockBlock(Material.PISTON, blockLocation);
+        BlockState replacedState = mock(BlockState.class);
+        BlockPlaceEvent event = new BlockPlaceEvent(block, replacedState, block,
+                new ItemStack(Material.PISTON), player, true, EquipmentSlot.HAND);
+        listener.onBlock(event);
+
+        assertTrue(event.isCancelled());
     }
 
     // --- Block cascade tests ---


### PR DESCRIPTION
Fixes #12 — the block half of group limits (entity groups shipped earlier). This is what #84 (piston + sticky piston) and #132 (grass→dirt conversion bypass) were closed into.

## Config

```yaml
blockgrouplimits:
  Pistons:
    icon: PISTON
    limit: 10
    materials:
    - PISTON
    - STICKY_PISTON
  Soil:
    icon: GRASS_BLOCK
    limit: 200
    materials:
    - GRASS_BLOCK
    - DIRT
    - DIRT_PATH
    - FARMLAND

blockgrouplimits-nether:
  Pistons: 5
```

Mirrors `entitygrouplimits` exactly: named group, icon, member list, shared limit, per-environment overrides (limit only). Member names normalise through the existing variant map, so e.g. a piston head resolves to its piston.

## Behaviour

- At placement (and every path that funnels through `process()` — grow, spread, form), the counts of all group members are **summed** and checked against the group limit. Converting grass→dirt no longer escapes the limit because both count into the same pool.
- The individual-limit cascade (island → world → env default) runs first and still applies inside a group, so a tighter per-material limit wins.
- The recount tracks group members even when they carry no individual limit; the config comment tells admins to recount after adding a group.
- The limits GUI gains a row per group: icon, member list, summed count/limit with the usual colouring.

## Notes / deliberate v1 scope

- The hit-limit message names the placed material with the group's limit value. Naming the group in the message (like entity groups do) needs `process()`'s int-return contract reworked across all state-transition handlers — worth doing separately if wanted.
- Permission-based block group limits (`<gm>.island.limit.<groupname>.<n>`) and group offsets are not included; both need `IslandBlockCount` data-model additions and can follow if there's demand.

## Tests

Settings parsing (definitions, env overrides, unknown material, undefined-group override), group-full cancels without double-count, under-limit allows and counts, tighter individual limit still applies. Full suite green (262).

## In-game test plan

1. Define the `Pistons` group above, restart, place 6 pistons + 4 sticky pistons.
2. The 11th of either kind is blocked; `/is limits` shows a Pistons row at 10/10.
3. Break one piston → a sticky piston can now be placed (9→10 again).
4. Set `blocklimits: PISTON: 3` as well → the 4th piston is blocked even with the group at 7/10.
5. `/is limits recount` → group count matches reality (including blocks placed before the group existed).
6. Nether: with the `-nether` override at 5, verify the pool is 5 there and 10 in the overworld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB