### PR TITLE
Add ItemsAdder and Oraxen custom block limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,16 @@
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <!-- ItemsAdder API (custom block limits) -->
+        <repository>
+            <id>matteodev</id>
+            <url>https://maven.devs.beer/</url>
+        </repository>
+        <!-- Oraxen API (custom block limits) -->
+        <repository>
+            <id>oraxen</id>
+            <url>https://repo.oraxen.com/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -191,6 +201,25 @@
             <artifactId>bentobox</artifactId>
             <version>${bentobox.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Custom block plugins, events only. Same versions as BentoBox compiles against. -->
+        <dependency>
+            <groupId>dev.lone</groupId>
+            <artifactId>api-itemsadder</artifactId>
+            <version>4.0.2-beta-release-11</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.th0rgal</groupId>
+            <artifactId>oraxen</artifactId>
+            <version>1.193.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/java/world/bentobox/limits/Limits.java
+++ b/src/main/java/world/bentobox/limits/Limits.java
@@ -69,6 +69,14 @@ public class Limits extends Addon {
         registerListener(joinListener);
         EntityLimitListener entityLimitListener = new EntityLimitListener(this);
         registerListener(entityLimitListener);
+        if (org.bukkit.Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
+            registerListener(new world.bentobox.limits.listeners.ItemsAdderListener(this));
+            log("ItemsAdder detected: custom block limits active. Use ItemsAdder ids as blocklimits keys.");
+        }
+        if (org.bukkit.Bukkit.getPluginManager().getPlugin("Oraxen") != null) {
+            registerListener(new world.bentobox.limits.listeners.OraxenListener(this));
+            log("Oraxen detected: custom block limits active. Use \"oraxen:<itemid>\" blocklimits keys.");
+        }
         try {
             Class.forName("io.papermc.paper.event.entity.ShulkerDuplicateEvent");
             registerListener(new PaperShulkerLimitListener(this, entityLimitListener));

--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -233,9 +233,24 @@ public class RecountCalculator {
 
     public void tidyUp() {
         ibc = bll.getIsland(island);
+        // Custom-namespace counts (ItemsAdder/Oraxen blocks) are event-tracked and
+        // invisible to the chunk scan, so carry them across the reset untouched.
+        Map<Environment, Map<NamespacedKey, Integer>> customCounts = new EnumMap<>(Environment.class);
+        for (Environment env : List.of(Environment.NORMAL, Environment.NETHER, Environment.THE_END)) {
+            ibc.getBlockCounts(env).forEach((key, count) -> {
+                if (!NamespacedKey.MINECRAFT.equals(key.getNamespace())) {
+                    customCounts.computeIfAbsent(env, e -> new java.util.HashMap<>()).put(key, count);
+                }
+            });
+        }
         // Reset and write per-env block counts
         ibc.clearAllBlockCounts();
         results.getEnvBlockCount().forEach((env, multiset) -> multiset.forEach(key -> ibc.add(env, key)));
+        customCounts.forEach((env, m) -> m.forEach((key, count) -> {
+            for (int i = 0; i < count; i++) {
+                ibc.add(env, key);
+            }
+        }));
 
         // Recount entities (loaded only) and write per-env
         scanEntities();

--- a/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/BlockLimitsListener.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -209,6 +210,13 @@ public class BlockLimitsListener implements Listener {
 
     /** Resolve a key to a material or block tag and store its limit, warning on any mismatch. */
     private void registerLimit(Map<NamespacedKey, Integer> limits, NamespacedKey nsKey, String key, int limit) {
+        if (!NamespacedKey.MINECRAFT.equals(nsKey.getNamespace())) {
+            // Custom-namespace key, e.g. an ItemsAdder block id ("iafestivities:christmas/tree")
+            // or an Oraxen id written as "oraxen:<itemid>". Enforced by the custom block
+            // listeners when the owning plugin is installed.
+            limits.put(nsKey, limit);
+            return;
+        }
         Material mat = Registry.MATERIAL.get(nsKey);
         if (mat != null) {
             if (!mat.isBlock()) {
@@ -445,7 +453,7 @@ public class BlockLimitsListener implements Listener {
      * @return limit amount if over limit, or -1 if no limitation
      */
     private int process(Block b, BlockData blockData, boolean add) {
-        if (DO_NOT_COUNT.contains(fixMaterial(blockData)) || !addon.inGameModeWorld(b.getWorld())) {
+        if (DO_NOT_COUNT.contains(fixMaterial(blockData))) {
             return -1;
         }
         // Stacked-plants-as-one: a segment sitting on the same plant is not counted,
@@ -454,21 +462,34 @@ public class BlockLimitsListener implements Listener {
                 && isSamePlant(b.getRelative(BlockFace.DOWN).getType(), fixMaterial(blockData))) {
             return -1;
         }
-        Environment env = envOf(b.getWorld());
-        return addon.getIslands().getIslandAt(b.getLocation()).map(i -> {
+        return processKey(b.getWorld(), b.getLocation(), fixMaterial(blockData), add);
+    }
+
+    /**
+     * Count and limit-check a namespaced key at a location. Public so custom-block
+     * listeners (ItemsAdder, Oraxen) can run their block ids through the same
+     * counting and limit machinery as vanilla blocks.
+     *
+     * @return limit amount if at/over the limit (nothing was counted), or -1 on success
+     */
+    public int processKey(World world, Location location, NamespacedKey key, boolean add) {
+        if (!addon.inGameModeWorld(world)) {
+            return -1;
+        }
+        Environment env = envOf(world);
+        return addon.getIslands().getIslandAt(location).map(i -> {
             String id = i.getUniqueId();
-            String gameMode = addon.getGameModeName(b.getWorld());
+            String gameMode = addon.getGameModeName(world);
             if (gameMode.isEmpty()) {
                 return -1;
             }
             if (addon.getConfig().getBoolean("ignore-center-block", true)
-                    && i.getCenter().equals(b.getLocation())) {
+                    && i.getCenter().equals(location)) {
                 return -1;
             }
             islandCountMap.putIfAbsent(id, new IslandBlockCount(id, gameMode));
-            NamespacedKey key = fixMaterial(blockData);
             if (add) {
-                int limit = checkLimit(b.getWorld(), env, key, id);
+                int limit = checkLimit(world, env, key, id);
                 if (limit > -1) {
                     return limit;
                 }

--- a/src/main/java/world/bentobox/limits/listeners/CustomBlockHandler.java
+++ b/src/main/java/world/bentobox/limits/listeners/CustomBlockHandler.java
@@ -1,0 +1,64 @@
+package world.bentobox.limits.listeners;
+
+import java.util.Locale;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
+import world.bentobox.limits.Limits;
+
+/**
+ * Shared plumbing for custom-block plugin listeners (ItemsAdder, Oraxen). Runs custom
+ * block ids through the same counting and limit machinery as vanilla blocks via
+ * {@link BlockLimitsListener#processKey}.
+ */
+final class CustomBlockHandler {
+
+    private CustomBlockHandler() {
+    }
+
+    /**
+     * Limit-check and count a custom block placement; cancels the event and notifies
+     * the player when the limit is hit.
+     */
+    static void place(Limits addon, Cancellable event, Player player, Block block, NamespacedKey key) {
+        if (key == null) {
+            return;
+        }
+        int limit = addon.getBlockLimitListener().processKey(block.getWorld(), block.getLocation(), key, true);
+        if (limit > -1) {
+            event.setCancelled(true);
+            if (player != null) {
+                User.getInstance(player).notify("block-limits.hit-limit",
+                        "[material]", Util.prettifyText(key.getKey()),
+                        TextVariables.NUMBER, String.valueOf(limit));
+            }
+        }
+    }
+
+    /**
+     * Decrement the count for a removed custom block.
+     */
+    static void remove(Limits addon, Block block, NamespacedKey key) {
+        if (key != null) {
+            addon.getBlockLimitListener().processKey(block.getWorld(), block.getLocation(), key, false);
+        }
+    }
+
+    /**
+     * Parse a custom block id into a namespaced key. ItemsAdder ids already carry a
+     * namespace; plain ids get the supplied default namespace (e.g. "oraxen").
+     */
+    static NamespacedKey toKey(String id, String defaultNamespace) {
+        if (id == null) {
+            return null;
+        }
+        String full = id.contains(":") ? id : defaultNamespace + ":" + id;
+        return NamespacedKey.fromString(full.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/world/bentobox/limits/listeners/ItemsAdderListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/ItemsAdderListener.java
@@ -1,0 +1,35 @@
+package world.bentobox.limits.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import dev.lone.itemsadder.api.Events.CustomBlockBreakEvent;
+import dev.lone.itemsadder.api.Events.CustomBlockPlaceEvent;
+import world.bentobox.limits.Limits;
+
+/**
+ * Applies block limits to ItemsAdder custom blocks. Registered only when the
+ * ItemsAdder plugin is present. Config keys use the ItemsAdder namespaced id, e.g.
+ * {@code "iafestivities:christmas/christmas_tree/green_orb": 5} under blocklimits.
+ */
+public class ItemsAdderListener implements Listener {
+
+    private final Limits addon;
+
+    public ItemsAdderListener(Limits addon) {
+        this.addon = addon;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlace(CustomBlockPlaceEvent e) {
+        CustomBlockHandler.place(addon, e, e.getPlayer(), e.getBlock(),
+                CustomBlockHandler.toKey(e.getNamespacedID(), "itemsadder"));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBreak(CustomBlockBreakEvent e) {
+        CustomBlockHandler.remove(addon, e.getBlock(),
+                CustomBlockHandler.toKey(e.getNamespacedID(), "itemsadder"));
+    }
+}

--- a/src/main/java/world/bentobox/limits/listeners/OraxenListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/OraxenListener.java
@@ -1,0 +1,51 @@
+package world.bentobox.limits.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import io.th0rgal.oraxen.api.events.noteblock.OraxenNoteBlockBreakEvent;
+import io.th0rgal.oraxen.api.events.noteblock.OraxenNoteBlockPlaceEvent;
+import io.th0rgal.oraxen.api.events.stringblock.OraxenStringBlockBreakEvent;
+import io.th0rgal.oraxen.api.events.stringblock.OraxenStringBlockPlaceEvent;
+import world.bentobox.limits.Limits;
+
+/**
+ * Applies block limits to Oraxen custom blocks (note-block and string-block
+ * mechanics). Registered only when the Oraxen plugin is present. Config keys use the
+ * {@code oraxen:} namespace, e.g. {@code "oraxen:caveblock": 10} under blocklimits.
+ */
+public class OraxenListener implements Listener {
+
+    private static final String NAMESPACE = "oraxen";
+
+    private final Limits addon;
+
+    public OraxenListener(Limits addon) {
+        this.addon = addon;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onNoteBlockPlace(OraxenNoteBlockPlaceEvent e) {
+        CustomBlockHandler.place(addon, e, e.getPlayer(), e.getBlock(),
+                CustomBlockHandler.toKey(e.getMechanic().getItemID(), NAMESPACE));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onNoteBlockBreak(OraxenNoteBlockBreakEvent e) {
+        CustomBlockHandler.remove(addon, e.getBlock(),
+                CustomBlockHandler.toKey(e.getMechanic().getItemID(), NAMESPACE));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onStringBlockPlace(OraxenStringBlockPlaceEvent e) {
+        CustomBlockHandler.place(addon, e, e.getPlayer(), e.getBlock(),
+                CustomBlockHandler.toKey(e.getMechanic().getItemID(), NAMESPACE));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onStringBlockBreak(OraxenStringBlockBreakEvent e) {
+        CustomBlockHandler.remove(addon, e.getBlock(),
+                CustomBlockHandler.toKey(e.getMechanic().getItemID(), NAMESPACE));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,6 +53,12 @@ apply-member-limit-perms: false
 # Use blocklimits-nether / blocklimits-end below to override per environment.
 # The following general terms can be used: STAIRS, DOORS, SIGNS, LOGS, SNOW, LEAVES,
 # SHULKER_BOXES, BANNERS, RAILS, ICE, BUTTONS, CANDLE_CAKES, CAMPFIRES, SLABS, STONE_BRICKS
+# ItemsAdder / Oraxen custom blocks can be limited too (when the plugin is installed):
+# use the ItemsAdder namespaced id, or an Oraxen id prefixed with "oraxen:", as the key.
+# Quote keys containing a colon. Custom blocks are tracked from their place/break
+# events; a recount preserves their stored counts rather than rescanning them.
+#  "iafestivities:christmas/christmas_tree/green_orb": 5
+#  "oraxen:caveblock": 10
 blocklimits:
   HOPPER: 10
 

--- a/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/BlockLimitsListenerTest.java
@@ -1097,6 +1097,34 @@ class BlockLimitsListenerTest {
         assertTrue(event.isCancelled());
     }
 
+    // --- Custom block keys (#176) ---
+
+    @Test
+    void testProcessKeyCustomNamespaceLimitAndCount() {
+        NamespacedKey custom = NamespacedKey.fromString("itemsadder:some_pack/tree");
+        IslandBlockCount ibc = new IslandBlockCount("test-island-id", "BSkyBlock");
+        ibc.setBlockLimit(Environment.NORMAL, custom, 1);
+        listener.setIsland("test-island-id", ibc);
+
+        // First add succeeds and counts
+        assertEquals(-1, listener.processKey(world, blockLocation, custom, true));
+        assertEquals(1, listener.getIsland("test-island-id").getBlockCount(Environment.NORMAL, custom));
+        // Second add hits the limit and must not count
+        assertEquals(1, listener.processKey(world, blockLocation, custom, true));
+        assertEquals(1, listener.getIsland("test-island-id").getBlockCount(Environment.NORMAL, custom));
+        // Removal decrements
+        assertEquals(-1, listener.processKey(world, blockLocation, custom, false));
+        assertEquals(0, listener.getIsland("test-island-id").getBlockCount(Environment.NORMAL, custom));
+    }
+
+    @Test
+    void testCustomNamespaceKeyAcceptedInBlockLimitsConfig() {
+        config.set("blocklimits.oraxen:caveblock", 10);
+        BlockLimitsListener custom = new BlockLimitsListener(addon);
+        assertEquals(10,
+                custom.getMaterialLimits(world, "no-island").get(NamespacedKey.fromString("oraxen:caveblock")));
+    }
+
     // --- Block cascade tests ---
 
     @Test

--- a/src/test/java/world/bentobox/limits/listeners/CustomBlockHandlerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/CustomBlockHandlerTest.java
@@ -1,0 +1,37 @@
+package world.bentobox.limits.listeners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.Test;
+
+class CustomBlockHandlerTest {
+
+    @Test
+    void testToKeyNamespacedIdPassesThrough() {
+        NamespacedKey key = CustomBlockHandler.toKey("iafestivities:christmas/christmas_tree/green_orb",
+                "itemsadder");
+        assertEquals("iafestivities", key.getNamespace());
+        assertEquals("christmas/christmas_tree/green_orb", key.getKey());
+    }
+
+    @Test
+    void testToKeyPlainIdGetsDefaultNamespace() {
+        NamespacedKey key = CustomBlockHandler.toKey("caveblock", "oraxen");
+        assertEquals("oraxen", key.getNamespace());
+        assertEquals("caveblock", key.getKey());
+    }
+
+    @Test
+    void testToKeyUppercaseIsLowercased() {
+        NamespacedKey key = CustomBlockHandler.toKey("CaveBlock", "oraxen");
+        assertEquals("caveblock", key.getKey());
+    }
+
+    @Test
+    void testToKeyInvalidReturnsNull() {
+        assertNull(CustomBlockHandler.toKey("bad key with spaces", "oraxen"));
+        assertNull(CustomBlockHandler.toKey(null, "oraxen"));
+    }
+}


### PR DESCRIPTION
Fixes #176.

## Config

No new section — custom ids go straight into the existing `blocklimits` machinery (including `-nether`/`-end` and `worlds:` overrides):

```yaml
blocklimits:
  HOPPER: 10
  "iafestivities:christmas/christmas_tree/green_orb": 5   # ItemsAdder namespaced id
  "oraxen:caveblock": 10                                   # Oraxen id, oraxen: prefix
```

The parser already produced `NamespacedKey`s for colon keys; `registerLimit` now accepts non-`minecraft` namespaces instead of rejecting them, and the per-env data model stores them natively (no migration).

## How enforcement works

Two thin listeners, registered **only when the respective plugin is installed** (no hard dependency; the API jars are `provided` at the same versions BentoBox compiles against):

- `ItemsAdderListener` — `CustomBlockPlaceEvent` / `CustomBlockBreakEvent`
- `OraxenListener` — note-block and string-block place/break events

Both feed `processKey`, a public extraction of the existing count/limit core, so island lookup, per-environment limits, offsets, save batching, and the limits GUI (paper icon + prettified name) all work unchanged. Listening to the plugins' own events is what fixes the 2023 blocker on this ticket — the old prototype raced Bukkit's block events and the block placed anyway; the custom events can't desync that way.

The recount chunk scan can't see custom blocks (they're physically note blocks etc.), so `RecountCalculator` now **carries non-minecraft counts across the reset** instead of zeroing them. Documented in the config comments.

## Deliberate v1 scope

- Oraxen furniture (entity-based) is not limited — note-block/string-block mechanics only.
- Permission-based limits don't match custom ids (perm segments are dot-separated; custom ids contain colons/slashes). Offsets via the admin command work.
- Per the ticket discussion: API access is BentoBox-hook style (no plugin API calls beyond their events); Nexo support would start with a BentoBox hook.

## Testing

JUnit covers `processKey` (limit hit, count, decrement for a custom key), config parsing of custom keys, and id→key mapping. **The listeners themselves need in-game verification with the real plugins** — @Olthoo offered to test back in 2023 and users were still asking in 2025:

1. Install ItemsAdder, add a custom block id with limit 2 to `blocklimits`, restart.
2. Place 2 of the block → 3rd is blocked with the hit-limit message *and the block does not appear* (this was the 2023 failure mode).
3. Break one → placement works again. `/is limits` shows the custom entry (paper icon).
4. `/is limits recount` → the custom count is unchanged afterwards.
5. Repeat with an Oraxen note-block id under `"oraxen:<id>"`.
6. Explosion/piston removal of a custom block → verify the plugin fires its break event and the count drops (if a gap shows up here, recount preserves rather than fixes custom counts — report it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB