### PR TITLE
Fix phantom entity counts left by portaled mobs

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -59,8 +59,6 @@ public class EntityLimitListener implements Listener {
     private final Limits addon;
     /** Entity UUIDs that have just spawned to prevent double-processing. */
     private final List<UUID> justSpawned = new ArrayList<>();
-    /** Entity UUIDs that are currently portaling to prevent double-decrement on cross-world removal. */
-    private final List<UUID> justPortaled = new ArrayList<>();
     /** Maps entity UUID to island ID so decrement works even when the entity dies off-island. */
     private final Map<UUID, String> entityIslandMap = new HashMap<>();
     /** Cardinal directions used for block structure detection. */
@@ -344,9 +342,6 @@ public class EntityLimitListener implements Listener {
         World w = entity.getWorld();
         if (!addon.inGameModeWorld(w)) return;
 
-        // Entity is being portaled — count transfer was already handled by onEntityPortal.
-        if (justPortaled.remove(entity.getUniqueId())) return;
-
         String islandId = entityIslandMap.remove(entity.getUniqueId());
         if (islandId != null) {
             addon.getBlockLimitListener().decrementEntity(islandId, envOf(w), entity.getType());
@@ -374,8 +369,9 @@ public class EntityLimitListener implements Listener {
         if (fromEnv == toEnv) return;
         if (!addon.inGameModeWorld(fromWorld) && !addon.inGameModeWorld(toWorld)) return;
 
-        // Prevent onEntityRemove from double-decrementing for the source-world removal.
-        justPortaled.add(entity.getUniqueId());
+        // No EntityRemoveEvent guard is needed here: Paper suppresses the event for
+        // dimension changes (RemovalReason.CHANGED_DIMENSION carries a null Bukkit cause),
+        // so the source-world removal never reaches onEntityRemove.
 
         // Decrement at source if on a tracked island
         if (addon.inGameModeWorld(fromWorld)) {

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -37,6 +37,7 @@ import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityBreedEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityRemoveEvent;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
@@ -801,6 +802,74 @@ class EntityLimitListenerTest {
         // before #270 this entry was lost on restart and the count drifted upward.
         assertEquals(before - 1, ibc.getEntityCount(Environment.NORMAL, EntityType.ENDERMAN));
         assertFalse(entityIslandMap().containsKey(enderman.getUniqueId()));
+    }
+
+    // --- EntityPortalEvent / phantom-count tests ---
+
+    @Test
+    void testEntityPortalTransfersCountBetweenEnvironments() throws Exception {
+        Location netherLoc = mockNetherLocation();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NORMAL, EntityType.CHICKEN));
+        assertEquals(1, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+        assertEquals("test-island-id", entityIslandMap().get(chicken.getUniqueId()));
+    }
+
+    @Test
+    void testPortaledEntityDeathStillDecrements() throws Exception {
+        // Regression: Paper never fires an EntityRemoveEvent for the dimension change itself
+        // (RemovalReason.CHANGED_DIMENSION has a null Bukkit cause), so the old justPortaled
+        // guard was never consumed and instead swallowed the entity's real death decrement,
+        // leaving a phantom count in the destination environment.
+        Location netherLoc = mockNetherLocation();
+        World nether = netherLoc.getWorld();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+        assertEquals(1, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+
+        // The entity now lives in the nether and dies there.
+        when(chicken.getWorld()).thenReturn(nether);
+        when(chicken.getLocation()).thenReturn(netherLoc);
+        ell.onEntityRemove(new EntityRemoveEvent(chicken, EntityRemoveEvent.Cause.DEATH));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+        assertFalse(entityIslandMap().containsKey(chicken.getUniqueId()));
+    }
+
+    @Test
+    void testRoundTripPortalThenDeathLeavesNoPhantomCount() throws Exception {
+        // The reported symptom: a mob portals to the nether, comes back, and dies in the
+        // overworld — the overworld count must return to zero, not stick at a phantom 1.
+        Location netherLoc = mockNetherLocation();
+        World nether = netherLoc.getWorld();
+        LivingEntity chicken = mockEntity(EntityType.CHICKEN, location);
+        ibc.incrementEntity(Environment.NORMAL, EntityType.CHICKEN);
+
+        ell.onEntityPortal(new EntityPortalEvent(chicken, location, netherLoc));
+        when(chicken.getWorld()).thenReturn(nether);
+        when(chicken.getLocation()).thenReturn(netherLoc);
+        ell.onEntityPortal(new EntityPortalEvent(chicken, netherLoc, location));
+        when(chicken.getWorld()).thenReturn(world);
+        when(chicken.getLocation()).thenReturn(location);
+
+        ell.onEntityRemove(new EntityRemoveEvent(chicken, EntityRemoveEvent.Cause.DEATH));
+
+        assertEquals(0, ibc.getEntityCount(Environment.NORMAL, EntityType.CHICKEN));
+        assertEquals(0, ibc.getEntityCount(Environment.NETHER, EntityType.CHICKEN));
+    }
+
+    private Location mockNetherLocation() {
+        World nether = mock(World.class);
+        when(nether.getEnvironment()).thenReturn(Environment.NETHER);
+        when(addon.inGameModeWorld(nether)).thenReturn(true);
+        Location netherLoc = mock(Location.class);
+        when(netherLoc.getWorld()).thenReturn(nether);
+        return netherLoc;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Problem

Server admins keep seeing entity limits (e.g. `Chicken 10/10`) with far fewer — or zero — of that mob actually on the island. A recount fixes it, then the count creeps back up.

## Root cause

`onEntityPortal` transfers the count between environments and recorded the entity in `justPortaled`, expecting the source-world removal to fire an `EntityRemoveEvent` that must be skipped. **That event never fires.** In Paper, `Entity.removeAfterChangingDimensions()` calls `setRemoved(RemovalReason.CHANGED_DIMENSION, null)` with a null Bukkit cause, and `CraftEventFactory.callEntityRemoveEvent()` returns early on a null cause — with a comment saying this is exactly the dimension-change case.

So the `justPortaled` entry was never consumed. When the mob later genuinely died, the stale entry swallowed the death decrement, leaving a permanent phantom +1 in the environment where it died. Every mob that ever crossed a portal contributed one on death (nether chicken jockeys wandering back through portals are a steady chicken-flavoured source of these). The `List` also grew unboundedly.

## Fix

Delete the `justPortaled` mechanism. The portal event alone moves the count between environments; the eventual death fires exactly one `EntityRemoveEvent`, in the destination world, and decrements normally.

## Tests

- `testEntityPortalTransfersCountBetweenEnvironments` — portal moves the count overworld → nether and updates the island mapping.
- `testPortaledEntityDeathStillDecrements` — portal then death leaves no phantom count (fails with `expected: <0> but was: <1>` on the old code).
- `testRoundTripPortalThenDeathLeavesNoPhantomCount` — the reported symptom: nether round trip then overworld death returns the overworld count to zero (also fails on the old code).

Full suite: 300 tests, all green. Verified both regression tests fail against the pre-fix listener.

Note for affected servers: phantom counts already in the database are corrected by running the admin `limits calc` recount once (with the island's players online so the chunks are loaded), after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dbJyrv2uxHfTmiWkqGUJB