### PR TITLE
Fix entity overcount from natural breeding and recount gaps

### DIFF
--- a/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
+++ b/src/main/java/world/bentobox/limits/calculators/RecountCalculator.java
@@ -25,6 +25,7 @@ import org.bukkit.block.data.type.Slab;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Vehicle;
 import org.bukkit.scheduler.BukkitTask;
 
 import world.bentobox.bentobox.BentoBox;
@@ -223,7 +224,7 @@ public class RecountCalculator {
             for (Entity entity : w.getEntities()) {
                 if (!island.inIslandSpace(entity.getLocation())) continue;
                 if (entity instanceof LivingEntity || entity instanceof Hanging
-                        || entity.getType().name().endsWith("_MINECART")
+                        || entity instanceof Vehicle
                         || entity.getType().name().equals("ARMOR_STAND")) {
                     results.getEntityCount(env).add(entity.getType());
                 }

--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -101,12 +101,19 @@ public class EntityLimitListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBreed(final EntityBreedEvent entityBreedEvent) {
-        if (addon.inGameModeWorld(entityBreedEvent.getEntity().getWorld())
-                && entityBreedEvent.getBreeder() != null
-                && (entityBreedEvent.getBreeder() instanceof Player player)
-                && !(player.isOp() || player.hasPermission(addon.getPlugin().getIWM()
-                        .getPermissionPrefix(entityBreedEvent.getEntity().getWorld()) + MOD_BYPASS))
-                && !checkLimit(entityBreedEvent, entityBreedEvent.getEntity(), SpawnReason.BREEDING, false)
+        if (!addon.inGameModeWorld(entityBreedEvent.getEntity().getWorld())) return;
+
+        boolean bypass = false;
+        if (entityBreedEvent.getBreeder() instanceof Player player) {
+            bypass = player.isOp() || player.hasPermission(addon.getPlugin().getIWM()
+                    .getPermissionPrefix(entityBreedEvent.getEntity().getWorld()) + MOD_BYPASS);
+        }
+
+        if (!bypass) {
+            checkLimit(entityBreedEvent, entityBreedEvent.getEntity(), SpawnReason.BREEDING, false);
+        }
+
+        if (entityBreedEvent.isCancelled()
                 && entityBreedEvent.getFather() instanceof Breedable father
                 && entityBreedEvent.getMother() instanceof Breedable mother) {
             father.setBreed(false);
@@ -309,6 +316,7 @@ public class EntityLimitListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityAddToWorld(EntityAddToWorldEvent e) {
         Entity entity = e.getEntity();
+        if (entity instanceof Player) return;
         if (!(entity instanceof LivingEntity) && !(entity instanceof Vehicle)
                 && !(entity instanceof Hanging)) {
             return;


### PR DESCRIPTION
- onBreed: natural breeding (bees, foxes, pandas) bypassed the limit
  because the check was gated behind `breeder instanceof Player`.
  Limit is now checked for all breeders; only Players can bypass.

- EntityAddToWorldEvent: Players passed the LivingEntity filter but
  EntityRemoveEvent never fires for them, leaking entries in the map.

- RecountCalculator: used `_MINECART` suffix instead of `instanceof
  Vehicle`, so boats were excluded from recounts.