### PR TITLE
Suppress hit-limit spam from natural breeding and add breed-path tests

### DIFF
--- a/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
+++ b/src/main/java/world/bentobox/limits/listeners/EntityLimitListener.java
@@ -103,6 +103,7 @@ public class EntityLimitListener implements Listener {
     public void onBreed(final EntityBreedEvent entityBreedEvent) {
         if (!addon.inGameModeWorld(entityBreedEvent.getEntity().getWorld())) return;
 
+        boolean playerBred = entityBreedEvent.getBreeder() instanceof Player;
         boolean bypass = false;
         if (entityBreedEvent.getBreeder() instanceof Player player) {
             bypass = player.isOp() || player.hasPermission(addon.getPlugin().getIWM()
@@ -110,9 +111,13 @@ public class EntityLimitListener implements Listener {
         }
 
         if (!bypass) {
-            checkLimit(entityBreedEvent, entityBreedEvent.getEntity(), SpawnReason.BREEDING, false);
+            // Natural breeding (villagers, bees, etc.) has no player to inform — suppress the
+            // hit-limit message so an auto-breeder at the limit doesn't spam nearby players.
+            checkLimit(entityBreedEvent, entityBreedEvent.getEntity(), SpawnReason.BREEDING, false, playerBred);
         }
 
+        // Cancelled breed: put both parents on a breeding cooldown so the pair doesn't retry
+        // immediately. Villagers are covered — AbstractVillager extends Breedable.
         if (entityBreedEvent.isCancelled()
                 && entityBreedEvent.getFather() instanceof Breedable father
                 && entityBreedEvent.getMother() instanceof Breedable mother) {
@@ -461,15 +466,20 @@ public class EntityLimitListener implements Listener {
 
     private boolean checkLimit(Cancellable cancelableEvent, LivingEntity livingEntity, SpawnReason spawnReason,
             boolean runAsync) {
+        return checkLimit(cancelableEvent, livingEntity, spawnReason, runAsync, true);
+    }
+
+    private boolean checkLimit(Cancellable cancelableEvent, LivingEntity livingEntity, SpawnReason spawnReason,
+            boolean runAsync, boolean notify) {
         Location l = livingEntity.getLocation();
         if (runAsync) {
             cancelableEvent.setCancelled(true);
         }
-        return processIsland(cancelableEvent, livingEntity, l, spawnReason, runAsync);
+        return processIsland(cancelableEvent, livingEntity, l, spawnReason, runAsync, notify);
     }
 
     private boolean processIsland(Cancellable cancelableEvent, LivingEntity livingEntity, Location location,
-            SpawnReason spawnReason, boolean runAsync) {
+            SpawnReason spawnReason, boolean runAsync, boolean notify) {
         Optional<Island> optionalIsland = addon.getIslands().getIslandAt(livingEntity.getLocation());
         if (optionalIsland.isEmpty()) {
             if (runAsync) {
@@ -490,7 +500,9 @@ public class EntityLimitListener implements Listener {
             } else {
                 cancelableEvent.setCancelled(true);
             }
-            tellPlayers(location, livingEntity, spawnReason, res);
+            if (notify) {
+                tellPlayers(location, livingEntity, spawnReason, res);
+            }
             return false;
         }
         return true;

--- a/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
+++ b/src/test/java/world/bentobox/limits/listeners/EntityLimitListenerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -347,23 +348,9 @@ class EntityLimitListenerTest {
         when(opPlayer.isOp()).thenReturn(true);
 
         // Create child, father, mother as Chicken mocks (implements Breedable)
-        Chicken child = mock(Chicken.class);
-        when(child.getType()).thenReturn(EntityType.CHICKEN);
-        when(child.getWorld()).thenReturn(world);
-        when(child.getLocation()).thenReturn(location);
-        when(child.getUniqueId()).thenReturn(UUID.randomUUID());
-
-        Chicken father = mock(Chicken.class);
-        when(father.getType()).thenReturn(EntityType.CHICKEN);
-        when(father.getWorld()).thenReturn(world);
-        when(father.getLocation()).thenReturn(location);
-        when(father.getUniqueId()).thenReturn(UUID.randomUUID());
-
-        Chicken mother = mock(Chicken.class);
-        when(mother.getType()).thenReturn(EntityType.CHICKEN);
-        when(mother.getWorld()).thenReturn(world);
-        when(mother.getLocation()).thenReturn(location);
-        when(mother.getUniqueId()).thenReturn(UUID.randomUUID());
+        Chicken child = mockChicken();
+        Chicken father = mockChicken();
+        Chicken mother = mockChicken();
 
         // Set CHICKEN limit to 0 so any entity would be over limit
         ibc.setEntityLimit(Environment.NORMAL, EntityType.CHICKEN, 0);
@@ -375,6 +362,82 @@ class EntityLimitListenerTest {
         // Op player bypasses — setBreed(false) should NOT be called
         verify(father, never()).setBreed(false);
         verify(mother, never()).setBreed(false);
+    }
+
+    @Test
+    void testBreedingNaturalAtLimitCancelsCoolsDownParentsAndDoesNotNotify() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.CHICKEN, 0);
+        Chicken child = mockChicken();
+        Chicken father = mockChicken();
+        Chicken mother = mockChicken();
+
+        // Null breeder = natural breeding (e.g. bees, foxes, villagers)
+        EntityBreedEvent event = new EntityBreedEvent(child, mother, father, null, null, 0);
+
+        ell.onBreed(event);
+
+        assertTrue(event.isCancelled());
+        verify(father).setBreed(false);
+        verify(mother).setBreed(false);
+        // No player caused this — the hit-limit notification must be suppressed
+        MockBukkit.getMock().getScheduler().performOneTick();
+        verify(world, never()).getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void testBreedingNaturalUnderLimitNotCancelled() {
+        // CHICKEN limit is 10 from config; count is zero
+        Chicken child = mockChicken();
+        Chicken father = mockChicken();
+        Chicken mother = mockChicken();
+
+        EntityBreedEvent event = new EntityBreedEvent(child, mother, father, null, null, 0);
+
+        ell.onBreed(event);
+
+        assertFalse(event.isCancelled());
+        verify(father, never()).setBreed(false);
+        verify(mother, never()).setBreed(false);
+    }
+
+    @Test
+    void testBreedingNonOpPlayerAtLimitCancelsAndNotifies() {
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.CHICKEN, 0);
+        Player breeder = mock(Player.class);
+        when(breeder.isOp()).thenReturn(false);
+        when(breeder.hasPermission(anyString())).thenReturn(false);
+        Chicken child = mockChicken();
+        Chicken father = mockChicken();
+        Chicken mother = mockChicken();
+
+        EntityBreedEvent event = new EntityBreedEvent(child, mother, father, breeder, null, 0);
+
+        ell.onBreed(event);
+
+        assertTrue(event.isCancelled());
+        verify(father).setBreed(false);
+        verify(mother).setBreed(false);
+        // A player fed the animals — the hit-limit notification is sent to nearby players
+        MockBukkit.getMock().getScheduler().performOneTick();
+        verify(world).getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void testBreedingVillagersAtLimitCancelsAndCoolsDownParents() {
+        // Villagers must hit the Breedable branch: AbstractVillager extends Breedable,
+        // so a cancelled villager breed also puts the parents on cooldown.
+        ibc.setEntityLimit(Environment.NORMAL, EntityType.VILLAGER, 0);
+        Villager child = mockVillager();
+        Villager father = mockVillager();
+        Villager mother = mockVillager();
+
+        EntityBreedEvent event = new EntityBreedEvent(child, mother, father, null, null, 0);
+
+        ell.onBreed(event);
+
+        assertTrue(event.isCancelled());
+        verify(father).setBreed(false);
+        verify(mother).setBreed(false);
     }
 
     // --- CreatureSpawn at-limit tests ---
@@ -733,6 +796,22 @@ class EntityLimitListenerTest {
     }
 
     @Test
+    void testEntityAddToWorldIgnoresPlayer() throws Exception {
+        // Players pass the LivingEntity filter but EntityRemoveEvent never fires for them,
+        // so mapping them would leak entries — they must be skipped entirely.
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(player.getLocation()).thenReturn(location);
+        when(player.getWorld()).thenReturn(world);
+        EntityAddToWorldEvent event = new EntityAddToWorldEvent(player, world);
+
+        ell.onEntityAddToWorld(event);
+
+        assertTrue(entityIslandMap().isEmpty());
+        verify(islandsManager, never()).getIslandAt(any(Location.class));
+    }
+
+    @Test
     void testEntityAddToWorldOutsideGameModeWorldIgnored() throws Exception {
         when(addon.inGameModeWorld(world)).thenReturn(false);
         LivingEntity enderman = mockEntity(EntityType.ENDERMAN, location);
@@ -888,6 +967,24 @@ class EntityLimitListenerTest {
         when(entity.getWorld()).thenReturn(world);
         when(entity.getUniqueId()).thenReturn(UUID.randomUUID());
         return entity;
+    }
+
+    private Chicken mockChicken() {
+        Chicken chicken = mock(Chicken.class);
+        when(chicken.getType()).thenReturn(EntityType.CHICKEN);
+        when(chicken.getLocation()).thenReturn(location);
+        when(chicken.getWorld()).thenReturn(world);
+        when(chicken.getUniqueId()).thenReturn(UUID.randomUUID());
+        return chicken;
+    }
+
+    private Villager mockVillager() {
+        Villager villager = mock(Villager.class);
+        when(villager.getType()).thenReturn(EntityType.VILLAGER);
+        when(villager.getLocation()).thenReturn(location);
+        when(villager.getWorld()).thenReturn(world);
+        when(villager.getUniqueId()).thenReturn(UUID.randomUUID());
+        return villager;
     }
 
     // --- Golem / snowman block-removal tests (#127) ---


### PR DESCRIPTION
Follow-up to #290, addressing the review notes.

### Notification suppression for natural breeding
`BREEDING` is not in `tellPlayers`' suppressed-reason list, so after #290 an automated breeder (e.g. a villager breeder at its limit) would notify every nearby player — and call `updateInventory()` — on every breed attempt. The limit check now threads a `notify` flag through `checkLimit`/`processIsland`: natural (null/non-player breeder) breeding cancels silently, while player-fed breeding still notifies so the player knows why no baby appeared and their food was kept.

### Villager cooldown — verified, no code change needed
The review flagged that villagers at the limit might retry every tick because "Villager isn't Breedable". That turned out to be outdated for the targeted API: `AbstractVillager extends Breedable` in Paper 1.21.11, so the existing `instanceof Breedable` branch already applies `setBreed(false)` (a breeding-age cooldown, which vanilla villager breeding also respects since it requires age == 0). A regression test now locks this in.

### New tests (45 → 50)
- Natural breeding at limit → cancelled, both parents put on cooldown, **no** notification scheduled
- Natural breeding under limit → not cancelled, parents untouched
- Non-op player breeding at limit → cancelled **with** notification to nearby players
- Villager natural breeding at limit → cancelled, `setBreed(false)` applied via the Breedable branch
- `EntityAddToWorldEvent` for a `Player` → not added to `entityIslandMap`, no island lookup (guards the leak fix from #290)

Also extracted `mockChicken()`/`mockVillager()` test helpers (the op-bypass test built the same three mocks inline).

Not covered: a `RecountCalculator` test for the boat fix — `scanEntities` is private inside the chunk-scanning pipeline and has no existing test scaffolding; building that is out of proportion for a one-line `instanceof` change.

Full suite: 305 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyA5AKzK44TXSxXQbR6DNc